### PR TITLE
chore: use a container for go commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ equinix-metal.swagger.json.orig
 .travis.yml
 git_push.sh
 services/*/api/
+pkg


### PR DESCRIPTION
This updates all `make` tasks to run go commands inside a container instead of on the host.  This prevents contributors from unintentionally running go commands with the wrong go version.