### PR TITLE
fix: specify correct type for interconnection speed

### DIFF
--- a/services/metalv1/docs/CreateOrganizationInterconnectionRequest.md
+++ b/services/metalv1/docs/CreateOrganizationInterconnectionRequest.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **Name** | **string** |  | 
 **Project** | Pointer to **string** |  | [optional] 
 **Redundancy** | **string** | Either &#39;primary&#39; or &#39;redundant&#39;. | 
-**Speed** | Pointer to **int32** | A interconnection speed, in bps, mbps, or gbps. For Fabric VCs, this represents the maximum speed of the interconnection. For Fabric VCs (Metal Billed), this can only be one of the following:  &#39;&#39;50mbps&#39;&#39;, &#39;&#39;200mbps&#39;&#39;, &#39;&#39;500mbps&#39;&#39;, &#39;&#39;1gbps&#39;&#39;, &#39;&#39;2gbps&#39;&#39;, &#39;&#39;5gbps&#39;&#39; or &#39;&#39;10gbps&#39;&#39;, and is required for creation. For Fabric VCs (Fabric Billed), this field will always default to &#39;&#39;10gbps&#39;&#39; even if it is not provided. For example, &#39;&#39;500000000&#39;&#39;, &#39;&#39;50m&#39;&#39;, or&#39; &#39;&#39;500mbps&#39;&#39; will all work as valid inputs. | [optional] 
+**Speed** | Pointer to **int64** | A interconnection speed, in bps, mbps, or gbps. For Fabric VCs, this represents the maximum speed of the interconnection. For Fabric VCs (Metal Billed), this can only be one of the following:  &#39;&#39;50mbps&#39;&#39;, &#39;&#39;200mbps&#39;&#39;, &#39;&#39;500mbps&#39;&#39;, &#39;&#39;1gbps&#39;&#39;, &#39;&#39;2gbps&#39;&#39;, &#39;&#39;5gbps&#39;&#39; or &#39;&#39;10gbps&#39;&#39;, and is required for creation. For Fabric VCs (Fabric Billed), this field will always default to &#39;&#39;10gbps&#39;&#39; even if it is not provided. For example, &#39;&#39;500000000&#39;&#39;, &#39;&#39;50m&#39;&#39;, or&#39; &#39;&#39;500mbps&#39;&#39; will all work as valid inputs. | [optional] 
 **Tags** | Pointer to **[]string** |  | [optional] 
 **Type** | [**VlanFabricVcCreateInputType**](VlanFabricVcCreateInputType.md) |  | 
 **UseCase** | Pointer to **string** | The intended use case of the dedicated port. | [optional] 
@@ -226,20 +226,20 @@ SetRedundancy sets Redundancy field to given value.
 
 ### GetSpeed
 
-`func (o *CreateOrganizationInterconnectionRequest) GetSpeed() int32`
+`func (o *CreateOrganizationInterconnectionRequest) GetSpeed() int64`
 
 GetSpeed returns the Speed field if non-nil, zero value otherwise.
 
 ### GetSpeedOk
 
-`func (o *CreateOrganizationInterconnectionRequest) GetSpeedOk() (*int32, bool)`
+`func (o *CreateOrganizationInterconnectionRequest) GetSpeedOk() (*int64, bool)`
 
 GetSpeedOk returns a tuple with the Speed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSpeed
 
-`func (o *CreateOrganizationInterconnectionRequest) SetSpeed(v int32)`
+`func (o *CreateOrganizationInterconnectionRequest) SetSpeed(v int64)`
 
 SetSpeed sets Speed field to given value.
 

--- a/services/metalv1/docs/DedicatedPortCreateInput.md
+++ b/services/metalv1/docs/DedicatedPortCreateInput.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **Name** | **string** |  | 
 **Project** | Pointer to **string** |  | [optional] 
 **Redundancy** | **string** | Either &#39;primary&#39; or &#39;redundant&#39;. | 
-**Speed** | Pointer to **int32** | A interconnection speed, in bps, mbps, or gbps. For Dedicated Ports, this can be 10Gbps or 100Gbps. | [optional] 
+**Speed** | Pointer to **int64** | A interconnection speed, in bps, mbps, or gbps. For Dedicated Ports, this can be 10Gbps or 100Gbps. | [optional] 
 **Tags** | Pointer to **[]string** |  | [optional] 
 **Type** | [**DedicatedPortCreateInputType**](DedicatedPortCreateInputType.md) |  | 
 **UseCase** | Pointer to **string** | The intended use case of the dedicated port. | [optional] 
@@ -223,20 +223,20 @@ SetRedundancy sets Redundancy field to given value.
 
 ### GetSpeed
 
-`func (o *DedicatedPortCreateInput) GetSpeed() int32`
+`func (o *DedicatedPortCreateInput) GetSpeed() int64`
 
 GetSpeed returns the Speed field if non-nil, zero value otherwise.
 
 ### GetSpeedOk
 
-`func (o *DedicatedPortCreateInput) GetSpeedOk() (*int32, bool)`
+`func (o *DedicatedPortCreateInput) GetSpeedOk() (*int64, bool)`
 
 GetSpeedOk returns a tuple with the Speed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSpeed
 
-`func (o *DedicatedPortCreateInput) SetSpeed(v int32)`
+`func (o *DedicatedPortCreateInput) SetSpeed(v int64)`
 
 SetSpeed sets Speed field to given value.
 

--- a/services/metalv1/docs/FabricServiceToken.md
+++ b/services/metalv1/docs/FabricServiceToken.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ExpiresAt** | Pointer to **time.Time** | The expiration date and time of the Fabric service token. Once a service token is expired, it is no longer redeemable. | [optional] 
 **Id** | Pointer to **string** | The UUID that can be used on the Fabric Portal to redeem either an A-Side or Z-Side Service Token. For Fabric VCs (Metal Billed), this UUID will represent an A-Side Service Token, which will allow interconnections to be made from Equinix Metal to other Service Providers on Fabric. For Fabric VCs (Fabric Billed), this UUID will represent a Z-Side Service Token, which will allow interconnections to be made to connect an owned Fabric Port or  Virtual Device to Equinix Metal. | [optional] 
-**MaxAllowedSpeed** | Pointer to **int32** | The maximum speed that can be selected on the Fabric Portal when configuring a interconnection with either  an A-Side or Z-Side Service Token. For Fabric VCs (Metal Billed), this is what the billing is based off of, and can be one of the following options, &#39;50mbps&#39;, &#39;200mbps&#39;, &#39;500mbps&#39;, &#39;1gbps&#39;, &#39;2gbps&#39;, &#39;5gbps&#39; or &#39;10gbps&#39;. For Fabric VCs (Fabric Billed), this will default to 10Gbps. | [optional] 
+**MaxAllowedSpeed** | Pointer to **int64** | The maximum speed that can be selected on the Fabric Portal when configuring a interconnection with either  an A-Side or Z-Side Service Token. For Fabric VCs (Metal Billed), this is what the billing is based off of, and can be one of the following options, &#39;50mbps&#39;, &#39;200mbps&#39;, &#39;500mbps&#39;, &#39;1gbps&#39;, &#39;2gbps&#39;, &#39;5gbps&#39; or &#39;10gbps&#39;. For Fabric VCs (Fabric Billed), this will default to 10Gbps. | [optional] 
 **Role** | Pointer to [**FabricServiceTokenRole**](FabricServiceTokenRole.md) |  | [optional] 
 **ServiceTokenType** | Pointer to [**FabricServiceTokenServiceTokenType**](FabricServiceTokenServiceTokenType.md) |  | [optional] 
 **State** | Pointer to [**FabricServiceTokenState**](FabricServiceTokenState.md) |  | [optional] 
@@ -82,20 +82,20 @@ HasId returns a boolean if a field has been set.
 
 ### GetMaxAllowedSpeed
 
-`func (o *FabricServiceToken) GetMaxAllowedSpeed() int32`
+`func (o *FabricServiceToken) GetMaxAllowedSpeed() int64`
 
 GetMaxAllowedSpeed returns the MaxAllowedSpeed field if non-nil, zero value otherwise.
 
 ### GetMaxAllowedSpeedOk
 
-`func (o *FabricServiceToken) GetMaxAllowedSpeedOk() (*int32, bool)`
+`func (o *FabricServiceToken) GetMaxAllowedSpeedOk() (*int64, bool)`
 
 GetMaxAllowedSpeedOk returns a tuple with the MaxAllowedSpeed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetMaxAllowedSpeed
 
-`func (o *FabricServiceToken) SetMaxAllowedSpeed(v int32)`
+`func (o *FabricServiceToken) SetMaxAllowedSpeed(v int64)`
 
 SetMaxAllowedSpeed sets MaxAllowedSpeed field to given value.
 

--- a/services/metalv1/docs/Interconnection.md
+++ b/services/metalv1/docs/Interconnection.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **Ports** | Pointer to [**[]InterconnectionPort**](InterconnectionPort.md) | For Fabric VCs, these represent Virtual Port(s) created for the interconnection. For dedicated interconnections, these represent the Dedicated Port(s). | [optional] 
 **Redundancy** | Pointer to [**InterconnectionRedundancy**](InterconnectionRedundancy.md) |  | [optional] 
 **ServiceTokens** | Pointer to [**[]FabricServiceToken**](FabricServiceToken.md) | For Fabric VCs (Metal Billed), this will show details of the A-Side service tokens issued for the interconnection. For Fabric VCs (Fabric Billed), this will show the details of the Z-Side service tokens issued for the interconnection. Dedicated interconnections will not have any service tokens issued. There will be one per interconnection, so for redundant interconnections, there should be two service tokens issued. | [optional] 
-**Speed** | Pointer to **int32** | For interconnections on Dedicated Ports and shared connections, this represents the interconnection&#39;s speed in bps. For Fabric VCs, this field refers to the maximum speed of the interconnection in bps. This value will default to 10Gbps for Fabric VCs (Fabric Billed). | [optional] 
+**Speed** | Pointer to **int64** | For interconnections on Dedicated Ports and shared connections, this represents the interconnection&#39;s speed in bps. For Fabric VCs, this field refers to the maximum speed of the interconnection in bps. This value will default to 10Gbps for Fabric VCs (Fabric Billed). | [optional] 
 **Status** | Pointer to **string** |  | [optional] 
 **Tags** | Pointer to **[]string** |  | [optional] 
 **Token** | Pointer to **string** | This token is used for shared interconnections to be used as the Fabric Token. This field is entirely deprecated. | [optional] 
@@ -320,20 +320,20 @@ HasServiceTokens returns a boolean if a field has been set.
 
 ### GetSpeed
 
-`func (o *Interconnection) GetSpeed() int32`
+`func (o *Interconnection) GetSpeed() int64`
 
 GetSpeed returns the Speed field if non-nil, zero value otherwise.
 
 ### GetSpeedOk
 
-`func (o *Interconnection) GetSpeedOk() (*int32, bool)`
+`func (o *Interconnection) GetSpeedOk() (*int64, bool)`
 
 GetSpeedOk returns a tuple with the Speed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSpeed
 
-`func (o *Interconnection) SetSpeed(v int32)`
+`func (o *Interconnection) SetSpeed(v int64)`
 
 SetSpeed sets Speed field to given value.
 

--- a/services/metalv1/docs/InterconnectionPort.md
+++ b/services/metalv1/docs/InterconnectionPort.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **SwitchId** | Pointer to **string** | A switch &#39;short ID&#39; | [optional] 
 **VirtualCircuits** | Pointer to [**[]VirtualCircuit**](VirtualCircuit.md) |  | [optional] 
 **Name** | Pointer to **string** |  | [optional] 
-**Speed** | Pointer to **int32** |  | [optional] 
+**Speed** | Pointer to **int64** |  | [optional] 
 **LinkStatus** | Pointer to **string** |  | [optional] 
 **Href** | Pointer to **string** |  | [optional] 
 
@@ -211,20 +211,20 @@ HasName returns a boolean if a field has been set.
 
 ### GetSpeed
 
-`func (o *InterconnectionPort) GetSpeed() int32`
+`func (o *InterconnectionPort) GetSpeed() int64`
 
 GetSpeed returns the Speed field if non-nil, zero value otherwise.
 
 ### GetSpeedOk
 
-`func (o *InterconnectionPort) GetSpeedOk() (*int32, bool)`
+`func (o *InterconnectionPort) GetSpeedOk() (*int64, bool)`
 
 GetSpeedOk returns a tuple with the Speed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSpeed
 
-`func (o *InterconnectionPort) SetSpeed(v int32)`
+`func (o *InterconnectionPort) SetSpeed(v int64)`
 
 SetSpeed sets Speed field to given value.
 

--- a/services/metalv1/docs/VirtualCircuit.md
+++ b/services/metalv1/docs/VirtualCircuit.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **NniVlan** | Pointer to **int32** |  | [optional] 
 **Port** | Pointer to [**Href**](Href.md) |  | [optional] 
 **Project** | Pointer to [**Href**](Href.md) |  | [optional] 
-**Speed** | Pointer to **int32** | integer representing bps speed | [optional] 
+**Speed** | Pointer to **int64** | integer representing bps speed | [optional] 
 **Status** | Pointer to [**VrfVirtualCircuitStatus**](VrfVirtualCircuitStatus.md) |  | [optional] 
 **Tags** | Pointer to **[]string** |  | [optional] 
 **Type** | Pointer to [**VrfIpReservationType**](VrfIpReservationType.md) |  | [optional] 
@@ -258,20 +258,20 @@ HasProject returns a boolean if a field has been set.
 
 ### GetSpeed
 
-`func (o *VirtualCircuit) GetSpeed() int32`
+`func (o *VirtualCircuit) GetSpeed() int64`
 
 GetSpeed returns the Speed field if non-nil, zero value otherwise.
 
 ### GetSpeedOk
 
-`func (o *VirtualCircuit) GetSpeedOk() (*int32, bool)`
+`func (o *VirtualCircuit) GetSpeedOk() (*int64, bool)`
 
 GetSpeedOk returns a tuple with the Speed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSpeed
 
-`func (o *VirtualCircuit) SetSpeed(v int32)`
+`func (o *VirtualCircuit) SetSpeed(v int64)`
 
 SetSpeed sets Speed field to given value.
 

--- a/services/metalv1/docs/VlanVirtualCircuit.md
+++ b/services/metalv1/docs/VlanVirtualCircuit.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **NniVlan** | Pointer to **int32** |  | [optional] 
 **Port** | Pointer to [**Href**](Href.md) |  | [optional] 
 **Project** | Pointer to [**Href**](Href.md) |  | [optional] 
-**Speed** | Pointer to **int32** | For Virtual Circuits on shared and dedicated connections, this speed should match the one set on their Interconnection Ports. For Virtual Circuits on Fabric VCs (both Metal and Fabric Billed) that have found their corresponding Fabric connection, this is the actual speed of the interconnection that was configured when setting up the interconnection on the Fabric Portal. Details on Fabric VCs are included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details. | [optional] 
+**Speed** | Pointer to **int64** | For Virtual Circuits on shared and dedicated connections, this speed should match the one set on their Interconnection Ports. For Virtual Circuits on Fabric VCs (both Metal and Fabric Billed) that have found their corresponding Fabric connection, this is the actual speed of the interconnection that was configured when setting up the interconnection on the Fabric Portal. Details on Fabric VCs are included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details. | [optional] 
 **Status** | Pointer to [**VlanVirtualCircuitStatus**](VlanVirtualCircuitStatus.md) |  | [optional] 
 **Tags** | Pointer to **[]string** |  | [optional] 
 **Type** | Pointer to [**VlanVirtualCircuitType**](VlanVirtualCircuitType.md) |  | [optional] 
@@ -252,20 +252,20 @@ HasProject returns a boolean if a field has been set.
 
 ### GetSpeed
 
-`func (o *VlanVirtualCircuit) GetSpeed() int32`
+`func (o *VlanVirtualCircuit) GetSpeed() int64`
 
 GetSpeed returns the Speed field if non-nil, zero value otherwise.
 
 ### GetSpeedOk
 
-`func (o *VlanVirtualCircuit) GetSpeedOk() (*int32, bool)`
+`func (o *VlanVirtualCircuit) GetSpeedOk() (*int64, bool)`
 
 GetSpeedOk returns a tuple with the Speed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSpeed
 
-`func (o *VlanVirtualCircuit) SetSpeed(v int32)`
+`func (o *VlanVirtualCircuit) SetSpeed(v int64)`
 
 SetSpeed sets Speed field to given value.
 

--- a/services/metalv1/docs/VlanVirtualCircuitCreateInput.md
+++ b/services/metalv1/docs/VlanVirtualCircuitCreateInput.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Name** | Pointer to **string** |  | [optional] 
 **NniVlan** | Pointer to **int32** |  | [optional] 
 **ProjectId** | **string** |  | 
-**Speed** | Pointer to **int32** | speed can be passed as integer number representing bps speed or string (e.g. &#39;52m&#39; or &#39;100g&#39; or &#39;4 gbps&#39;) | [optional] 
+**Speed** | Pointer to **int64** | speed can be passed as integer number representing bps speed or string (e.g. &#39;52m&#39; or &#39;100g&#39; or &#39;4 gbps&#39;) | [optional] 
 **Tags** | Pointer to **[]string** |  | [optional] 
 **Vnid** | Pointer to **string** | A Virtual Network record UUID or the VNID of a Metro Virtual Network in your project (sent as integer). | [optional] 
 
@@ -128,20 +128,20 @@ SetProjectId sets ProjectId field to given value.
 
 ### GetSpeed
 
-`func (o *VlanVirtualCircuitCreateInput) GetSpeed() int32`
+`func (o *VlanVirtualCircuitCreateInput) GetSpeed() int64`
 
 GetSpeed returns the Speed field if non-nil, zero value otherwise.
 
 ### GetSpeedOk
 
-`func (o *VlanVirtualCircuitCreateInput) GetSpeedOk() (*int32, bool)`
+`func (o *VlanVirtualCircuitCreateInput) GetSpeedOk() (*int64, bool)`
 
 GetSpeedOk returns a tuple with the Speed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSpeed
 
-`func (o *VlanVirtualCircuitCreateInput) SetSpeed(v int32)`
+`func (o *VlanVirtualCircuitCreateInput) SetSpeed(v int64)`
 
 SetSpeed sets Speed field to given value.
 

--- a/services/metalv1/docs/VrfFabricVcCreateInput.md
+++ b/services/metalv1/docs/VrfFabricVcCreateInput.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **Project** | Pointer to **string** |  | [optional] 
 **Redundancy** | **string** | Either &#39;primary&#39; or &#39;redundant&#39;. | 
 **ServiceTokenType** | [**VlanFabricVcCreateInputServiceTokenType**](VlanFabricVcCreateInputServiceTokenType.md) |  | 
-**Speed** | Pointer to **int32** | A interconnection speed, in bps, mbps, or gbps. For Fabric VCs, this represents the maximum speed of the interconnection. For Fabric VCs (Metal Billed), this can only be one of the following:  &#39;&#39;50mbps&#39;&#39;, &#39;&#39;200mbps&#39;&#39;, &#39;&#39;500mbps&#39;&#39;, &#39;&#39;1gbps&#39;&#39;, &#39;&#39;2gbps&#39;&#39;, &#39;&#39;5gbps&#39;&#39; or &#39;&#39;10gbps&#39;&#39;, and is required for creation. For Fabric VCs (Fabric Billed), this field will always default to &#39;&#39;10gbps&#39;&#39; even if it is not provided. For example, &#39;&#39;500000000&#39;&#39;, &#39;&#39;50m&#39;&#39;, or&#39; &#39;&#39;500mbps&#39;&#39; will all work as valid inputs. | [optional] 
+**Speed** | Pointer to **int64** | A interconnection speed, in bps, mbps, or gbps. For Fabric VCs, this represents the maximum speed of the interconnection. For Fabric VCs (Metal Billed), this can only be one of the following:  &#39;&#39;50mbps&#39;&#39;, &#39;&#39;200mbps&#39;&#39;, &#39;&#39;500mbps&#39;&#39;, &#39;&#39;1gbps&#39;&#39;, &#39;&#39;2gbps&#39;&#39;, &#39;&#39;5gbps&#39;&#39; or &#39;&#39;10gbps&#39;&#39;, and is required for creation. For Fabric VCs (Fabric Billed), this field will always default to &#39;&#39;10gbps&#39;&#39; even if it is not provided. For example, &#39;&#39;500000000&#39;&#39;, &#39;&#39;50m&#39;&#39;, or&#39; &#39;&#39;500mbps&#39;&#39; will all work as valid inputs. | [optional] 
 **Tags** | Pointer to **[]string** |  | [optional] 
 **Type** | [**VlanFabricVcCreateInputType**](VlanFabricVcCreateInputType.md) |  | 
 **Vrfs** | **[]string** | This field holds a list of VRF UUIDs that will be set automatically on the virtual circuits of Fabric VCs on creation, and can hold up to two UUIDs. Two UUIDs are required when requesting redundant Fabric VCs. The first UUID will be set on the primary virtual circuit, while the second UUID will be set on the secondary. The two UUIDs can be the same if both the primary and secondary virtual circuits will be in the same VRF. This parameter is included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details. | 
@@ -192,20 +192,20 @@ SetServiceTokenType sets ServiceTokenType field to given value.
 
 ### GetSpeed
 
-`func (o *VrfFabricVcCreateInput) GetSpeed() int32`
+`func (o *VrfFabricVcCreateInput) GetSpeed() int64`
 
 GetSpeed returns the Speed field if non-nil, zero value otherwise.
 
 ### GetSpeedOk
 
-`func (o *VrfFabricVcCreateInput) GetSpeedOk() (*int32, bool)`
+`func (o *VrfFabricVcCreateInput) GetSpeedOk() (*int64, bool)`
 
 GetSpeedOk returns a tuple with the Speed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSpeed
 
-`func (o *VrfFabricVcCreateInput) SetSpeed(v int32)`
+`func (o *VrfFabricVcCreateInput) SetSpeed(v int64)`
 
 SetSpeed sets Speed field to given value.
 

--- a/services/metalv1/docs/VrfVirtualCircuit.md
+++ b/services/metalv1/docs/VrfVirtualCircuit.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **NniVlan** | Pointer to **int32** |  | [optional] 
 **PeerAsn** | Pointer to **int32** | The peer ASN that will be used with the VRF on the Virtual Circuit. | [optional] 
 **Project** | Pointer to [**Href**](Href.md) |  | [optional] 
-**Speed** | Pointer to **int32** | integer representing bps speed | [optional] 
+**Speed** | Pointer to **int64** | integer representing bps speed | [optional] 
 **Status** | Pointer to [**VrfVirtualCircuitStatus**](VrfVirtualCircuitStatus.md) |  | [optional] 
 **Subnet** | Pointer to **string** | The /30 or /31 subnet of one of the VRF IP Blocks that will be used with the VRF for the Virtual Circuit. This subnet does not have to be an existing VRF IP reservation, as we will create the VRF IP reservation on creation if it does not exist. The Metal IP and Customer IP must be IPs from this subnet. For /30 subnets, the network and broadcast IPs cannot be used as the Metal or Customer IP. | [optional] 
 **Tags** | Pointer to **[]string** |  | [optional] 
@@ -294,20 +294,20 @@ HasProject returns a boolean if a field has been set.
 
 ### GetSpeed
 
-`func (o *VrfVirtualCircuit) GetSpeed() int32`
+`func (o *VrfVirtualCircuit) GetSpeed() int64`
 
 GetSpeed returns the Speed field if non-nil, zero value otherwise.
 
 ### GetSpeedOk
 
-`func (o *VrfVirtualCircuit) GetSpeedOk() (*int32, bool)`
+`func (o *VrfVirtualCircuit) GetSpeedOk() (*int64, bool)`
 
 GetSpeedOk returns a tuple with the Speed field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSpeed
 
-`func (o *VrfVirtualCircuit) SetSpeed(v int32)`
+`func (o *VrfVirtualCircuit) SetSpeed(v int64)`
 
 SetSpeed sets Speed field to given value.
 

--- a/services/metalv1/model_dedicated_port_create_input.go
+++ b/services/metalv1/model_dedicated_port_create_input.go
@@ -34,7 +34,7 @@ type DedicatedPortCreateInput struct {
 	// Either 'primary' or 'redundant'.
 	Redundancy string `json:"redundancy"`
 	// A interconnection speed, in bps, mbps, or gbps. For Dedicated Ports, this can be 10Gbps or 100Gbps.
-	Speed *int32                       `json:"speed,omitempty"`
+	Speed *int64                       `json:"speed,omitempty"`
 	Tags  []string                     `json:"tags,omitempty"`
 	Type  DedicatedPortCreateInputType `json:"type"`
 	// The intended use case of the dedicated port.
@@ -298,9 +298,9 @@ func (o *DedicatedPortCreateInput) SetRedundancy(v string) {
 }
 
 // GetSpeed returns the Speed field value if set, zero value otherwise.
-func (o *DedicatedPortCreateInput) GetSpeed() int32 {
+func (o *DedicatedPortCreateInput) GetSpeed() int64 {
 	if o == nil || IsNil(o.Speed) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.Speed
@@ -308,7 +308,7 @@ func (o *DedicatedPortCreateInput) GetSpeed() int32 {
 
 // GetSpeedOk returns a tuple with the Speed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DedicatedPortCreateInput) GetSpeedOk() (*int32, bool) {
+func (o *DedicatedPortCreateInput) GetSpeedOk() (*int64, bool) {
 	if o == nil || IsNil(o.Speed) {
 		return nil, false
 	}
@@ -324,8 +324,8 @@ func (o *DedicatedPortCreateInput) HasSpeed() bool {
 	return false
 }
 
-// SetSpeed gets a reference to the given int32 and assigns it to the Speed field.
-func (o *DedicatedPortCreateInput) SetSpeed(v int32) {
+// SetSpeed gets a reference to the given int64 and assigns it to the Speed field.
+func (o *DedicatedPortCreateInput) SetSpeed(v int64) {
 	o.Speed = &v
 }
 

--- a/services/metalv1/model_fabric_service_token.go
+++ b/services/metalv1/model_fabric_service_token.go
@@ -26,7 +26,7 @@ type FabricServiceToken struct {
 	// The UUID that can be used on the Fabric Portal to redeem either an A-Side or Z-Side Service Token. For Fabric VCs (Metal Billed), this UUID will represent an A-Side Service Token, which will allow interconnections to be made from Equinix Metal to other Service Providers on Fabric. For Fabric VCs (Fabric Billed), this UUID will represent a Z-Side Service Token, which will allow interconnections to be made to connect an owned Fabric Port or  Virtual Device to Equinix Metal.
 	Id *string `json:"id,omitempty"`
 	// The maximum speed that can be selected on the Fabric Portal when configuring a interconnection with either  an A-Side or Z-Side Service Token. For Fabric VCs (Metal Billed), this is what the billing is based off of, and can be one of the following options, '50mbps', '200mbps', '500mbps', '1gbps', '2gbps', '5gbps' or '10gbps'. For Fabric VCs (Fabric Billed), this will default to 10Gbps.
-	MaxAllowedSpeed      *int32                              `json:"max_allowed_speed,omitempty"`
+	MaxAllowedSpeed      *int64                              `json:"max_allowed_speed,omitempty"`
 	Role                 *FabricServiceTokenRole             `json:"role,omitempty"`
 	ServiceTokenType     *FabricServiceTokenServiceTokenType `json:"service_token_type,omitempty"`
 	State                *FabricServiceTokenState            `json:"state,omitempty"`
@@ -117,9 +117,9 @@ func (o *FabricServiceToken) SetId(v string) {
 }
 
 // GetMaxAllowedSpeed returns the MaxAllowedSpeed field value if set, zero value otherwise.
-func (o *FabricServiceToken) GetMaxAllowedSpeed() int32 {
+func (o *FabricServiceToken) GetMaxAllowedSpeed() int64 {
 	if o == nil || IsNil(o.MaxAllowedSpeed) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.MaxAllowedSpeed
@@ -127,7 +127,7 @@ func (o *FabricServiceToken) GetMaxAllowedSpeed() int32 {
 
 // GetMaxAllowedSpeedOk returns a tuple with the MaxAllowedSpeed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *FabricServiceToken) GetMaxAllowedSpeedOk() (*int32, bool) {
+func (o *FabricServiceToken) GetMaxAllowedSpeedOk() (*int64, bool) {
 	if o == nil || IsNil(o.MaxAllowedSpeed) {
 		return nil, false
 	}
@@ -143,8 +143,8 @@ func (o *FabricServiceToken) HasMaxAllowedSpeed() bool {
 	return false
 }
 
-// SetMaxAllowedSpeed gets a reference to the given int32 and assigns it to the MaxAllowedSpeed field.
-func (o *FabricServiceToken) SetMaxAllowedSpeed(v int32) {
+// SetMaxAllowedSpeed gets a reference to the given int64 and assigns it to the MaxAllowedSpeed field.
+func (o *FabricServiceToken) SetMaxAllowedSpeed(v int64) {
 	o.MaxAllowedSpeed = &v
 }
 

--- a/services/metalv1/model_interconnection.go
+++ b/services/metalv1/model_interconnection.go
@@ -35,7 +35,7 @@ type Interconnection struct {
 	// For Fabric VCs (Metal Billed), this will show details of the A-Side service tokens issued for the interconnection. For Fabric VCs (Fabric Billed), this will show the details of the Z-Side service tokens issued for the interconnection. Dedicated interconnections will not have any service tokens issued. There will be one per interconnection, so for redundant interconnections, there should be two service tokens issued.
 	ServiceTokens []FabricServiceToken `json:"service_tokens,omitempty"`
 	// For interconnections on Dedicated Ports and shared connections, this represents the interconnection's speed in bps. For Fabric VCs, this field refers to the maximum speed of the interconnection in bps. This value will default to 10Gbps for Fabric VCs (Fabric Billed).
-	Speed  *int32   `json:"speed,omitempty"`
+	Speed  *int64   `json:"speed,omitempty"`
 	Status *string  `json:"status,omitempty"`
 	Tags   []string `json:"tags,omitempty"`
 	// This token is used for shared interconnections to be used as the Fabric Token. This field is entirely deprecated.
@@ -419,9 +419,9 @@ func (o *Interconnection) SetServiceTokens(v []FabricServiceToken) {
 }
 
 // GetSpeed returns the Speed field value if set, zero value otherwise.
-func (o *Interconnection) GetSpeed() int32 {
+func (o *Interconnection) GetSpeed() int64 {
 	if o == nil || IsNil(o.Speed) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.Speed
@@ -429,7 +429,7 @@ func (o *Interconnection) GetSpeed() int32 {
 
 // GetSpeedOk returns a tuple with the Speed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Interconnection) GetSpeedOk() (*int32, bool) {
+func (o *Interconnection) GetSpeedOk() (*int64, bool) {
 	if o == nil || IsNil(o.Speed) {
 		return nil, false
 	}
@@ -445,8 +445,8 @@ func (o *Interconnection) HasSpeed() bool {
 	return false
 }
 
-// SetSpeed gets a reference to the given int32 and assigns it to the Speed field.
-func (o *Interconnection) SetSpeed(v int32) {
+// SetSpeed gets a reference to the given int64 and assigns it to the Speed field.
+func (o *Interconnection) SetSpeed(v int64) {
 	o.Speed = &v
 }
 

--- a/services/metalv1/model_interconnection_port.go
+++ b/services/metalv1/model_interconnection_port.go
@@ -28,7 +28,7 @@ type InterconnectionPort struct {
 	SwitchId             *string          `json:"switch_id,omitempty"`
 	VirtualCircuits      []VirtualCircuit `json:"virtual_circuits,omitempty"`
 	Name                 *string          `json:"name,omitempty"`
-	Speed                *int32           `json:"speed,omitempty"`
+	Speed                *int64           `json:"speed,omitempty"`
 	LinkStatus           *string          `json:"link_status,omitempty"`
 	Href                 *string          `json:"href,omitempty"`
 	AdditionalProperties map[string]interface{}
@@ -278,9 +278,9 @@ func (o *InterconnectionPort) SetName(v string) {
 }
 
 // GetSpeed returns the Speed field value if set, zero value otherwise.
-func (o *InterconnectionPort) GetSpeed() int32 {
+func (o *InterconnectionPort) GetSpeed() int64 {
 	if o == nil || IsNil(o.Speed) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.Speed
@@ -288,7 +288,7 @@ func (o *InterconnectionPort) GetSpeed() int32 {
 
 // GetSpeedOk returns a tuple with the Speed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InterconnectionPort) GetSpeedOk() (*int32, bool) {
+func (o *InterconnectionPort) GetSpeedOk() (*int64, bool) {
 	if o == nil || IsNil(o.Speed) {
 		return nil, false
 	}
@@ -304,8 +304,8 @@ func (o *InterconnectionPort) HasSpeed() bool {
 	return false
 }
 
-// SetSpeed gets a reference to the given int32 and assigns it to the Speed field.
-func (o *InterconnectionPort) SetSpeed(v int32) {
+// SetSpeed gets a reference to the given int64 and assigns it to the Speed field.
+func (o *InterconnectionPort) SetSpeed(v int64) {
 	o.Speed = &v
 }
 

--- a/services/metalv1/model_vlan_virtual_circuit.go
+++ b/services/metalv1/model_vlan_virtual_circuit.go
@@ -31,7 +31,7 @@ type VlanVirtualCircuit struct {
 	Port        *Href                              `json:"port,omitempty"`
 	Project     *Href                              `json:"project,omitempty"`
 	// For Virtual Circuits on shared and dedicated connections, this speed should match the one set on their Interconnection Ports. For Virtual Circuits on Fabric VCs (both Metal and Fabric Billed) that have found their corresponding Fabric connection, this is the actual speed of the interconnection that was configured when setting up the interconnection on the Fabric Portal. Details on Fabric VCs are included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
-	Speed                *int32                    `json:"speed,omitempty"`
+	Speed                *int64                    `json:"speed,omitempty"`
 	Status               *VlanVirtualCircuitStatus `json:"status,omitempty"`
 	Tags                 []string                  `json:"tags,omitempty"`
 	Type                 *VlanVirtualCircuitType   `json:"type,omitempty"`
@@ -333,9 +333,9 @@ func (o *VlanVirtualCircuit) SetProject(v Href) {
 }
 
 // GetSpeed returns the Speed field value if set, zero value otherwise.
-func (o *VlanVirtualCircuit) GetSpeed() int32 {
+func (o *VlanVirtualCircuit) GetSpeed() int64 {
 	if o == nil || IsNil(o.Speed) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.Speed
@@ -343,7 +343,7 @@ func (o *VlanVirtualCircuit) GetSpeed() int32 {
 
 // GetSpeedOk returns a tuple with the Speed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *VlanVirtualCircuit) GetSpeedOk() (*int32, bool) {
+func (o *VlanVirtualCircuit) GetSpeedOk() (*int64, bool) {
 	if o == nil || IsNil(o.Speed) {
 		return nil, false
 	}
@@ -359,8 +359,8 @@ func (o *VlanVirtualCircuit) HasSpeed() bool {
 	return false
 }
 
-// SetSpeed gets a reference to the given int32 and assigns it to the Speed field.
-func (o *VlanVirtualCircuit) SetSpeed(v int32) {
+// SetSpeed gets a reference to the given int64 and assigns it to the Speed field.
+func (o *VlanVirtualCircuit) SetSpeed(v int64) {
 	o.Speed = &v
 }
 

--- a/services/metalv1/model_vlan_virtual_circuit_create_input.go
+++ b/services/metalv1/model_vlan_virtual_circuit_create_input.go
@@ -26,7 +26,7 @@ type VlanVirtualCircuitCreateInput struct {
 	NniVlan     *int32  `json:"nni_vlan,omitempty"`
 	ProjectId   string  `json:"project_id"`
 	// speed can be passed as integer number representing bps speed or string (e.g. '52m' or '100g' or '4 gbps')
-	Speed *int32   `json:"speed,omitempty"`
+	Speed *int64   `json:"speed,omitempty"`
 	Tags  []string `json:"tags,omitempty"`
 	// A Virtual Network record UUID or the VNID of a Metro Virtual Network in your project (sent as integer).
 	Vnid                 *string `json:"vnid,omitempty"`
@@ -174,9 +174,9 @@ func (o *VlanVirtualCircuitCreateInput) SetProjectId(v string) {
 }
 
 // GetSpeed returns the Speed field value if set, zero value otherwise.
-func (o *VlanVirtualCircuitCreateInput) GetSpeed() int32 {
+func (o *VlanVirtualCircuitCreateInput) GetSpeed() int64 {
 	if o == nil || IsNil(o.Speed) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.Speed
@@ -184,7 +184,7 @@ func (o *VlanVirtualCircuitCreateInput) GetSpeed() int32 {
 
 // GetSpeedOk returns a tuple with the Speed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *VlanVirtualCircuitCreateInput) GetSpeedOk() (*int32, bool) {
+func (o *VlanVirtualCircuitCreateInput) GetSpeedOk() (*int64, bool) {
 	if o == nil || IsNil(o.Speed) {
 		return nil, false
 	}
@@ -200,8 +200,8 @@ func (o *VlanVirtualCircuitCreateInput) HasSpeed() bool {
 	return false
 }
 
-// SetSpeed gets a reference to the given int32 and assigns it to the Speed field.
-func (o *VlanVirtualCircuitCreateInput) SetSpeed(v int32) {
+// SetSpeed gets a reference to the given int64 and assigns it to the Speed field.
+func (o *VlanVirtualCircuitCreateInput) SetSpeed(v int64) {
 	o.Speed = &v
 }
 

--- a/services/metalv1/model_vrf_fabric_vc_create_input.go
+++ b/services/metalv1/model_vrf_fabric_vc_create_input.go
@@ -32,7 +32,7 @@ type VrfFabricVcCreateInput struct {
 	Redundancy       string                                  `json:"redundancy"`
 	ServiceTokenType VlanFabricVcCreateInputServiceTokenType `json:"service_token_type"`
 	// A interconnection speed, in bps, mbps, or gbps. For Fabric VCs, this represents the maximum speed of the interconnection. For Fabric VCs (Metal Billed), this can only be one of the following:  ''50mbps'', ''200mbps'', ''500mbps'', ''1gbps'', ''2gbps'', ''5gbps'' or ''10gbps'', and is required for creation. For Fabric VCs (Fabric Billed), this field will always default to ''10gbps'' even if it is not provided. For example, ''500000000'', ''50m'', or' ''500mbps'' will all work as valid inputs.
-	Speed *int32                      `json:"speed,omitempty"`
+	Speed *int64                      `json:"speed,omitempty"`
 	Tags  []string                    `json:"tags,omitempty"`
 	Type  VlanFabricVcCreateInputType `json:"type"`
 	// This field holds a list of VRF UUIDs that will be set automatically on the virtual circuits of Fabric VCs on creation, and can hold up to two UUIDs. Two UUIDs are required when requesting redundant Fabric VCs. The first UUID will be set on the primary virtual circuit, while the second UUID will be set on the secondary. The two UUIDs can be the same if both the primary and secondary virtual circuits will be in the same VRF. This parameter is included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
@@ -258,9 +258,9 @@ func (o *VrfFabricVcCreateInput) SetServiceTokenType(v VlanFabricVcCreateInputSe
 }
 
 // GetSpeed returns the Speed field value if set, zero value otherwise.
-func (o *VrfFabricVcCreateInput) GetSpeed() int32 {
+func (o *VrfFabricVcCreateInput) GetSpeed() int64 {
 	if o == nil || IsNil(o.Speed) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.Speed
@@ -268,7 +268,7 @@ func (o *VrfFabricVcCreateInput) GetSpeed() int32 {
 
 // GetSpeedOk returns a tuple with the Speed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *VrfFabricVcCreateInput) GetSpeedOk() (*int32, bool) {
+func (o *VrfFabricVcCreateInput) GetSpeedOk() (*int64, bool) {
 	if o == nil || IsNil(o.Speed) {
 		return nil, false
 	}
@@ -284,8 +284,8 @@ func (o *VrfFabricVcCreateInput) HasSpeed() bool {
 	return false
 }
 
-// SetSpeed gets a reference to the given int32 and assigns it to the Speed field.
-func (o *VrfFabricVcCreateInput) SetSpeed(v int32) {
+// SetSpeed gets a reference to the given int64 and assigns it to the Speed field.
+func (o *VrfFabricVcCreateInput) SetSpeed(v int64) {
 	o.Speed = &v
 }
 

--- a/services/metalv1/model_vrf_virtual_circuit.go
+++ b/services/metalv1/model_vrf_virtual_circuit.go
@@ -37,7 +37,7 @@ type VrfVirtualCircuit struct {
 	PeerAsn *int32 `json:"peer_asn,omitempty"`
 	Project *Href  `json:"project,omitempty"`
 	// integer representing bps speed
-	Speed  *int32                   `json:"speed,omitempty"`
+	Speed  *int64                   `json:"speed,omitempty"`
 	Status *VrfVirtualCircuitStatus `json:"status,omitempty"`
 	// The /30 or /31 subnet of one of the VRF IP Blocks that will be used with the VRF for the Virtual Circuit. This subnet does not have to be an existing VRF IP reservation, as we will create the VRF IP reservation on creation if it does not exist. The Metal IP and Customer IP must be IPs from this subnet. For /30 subnets, the network and broadcast IPs cannot be used as the Metal or Customer IP.
 	Subnet               *string               `json:"subnet,omitempty"`
@@ -390,9 +390,9 @@ func (o *VrfVirtualCircuit) SetProject(v Href) {
 }
 
 // GetSpeed returns the Speed field value if set, zero value otherwise.
-func (o *VrfVirtualCircuit) GetSpeed() int32 {
+func (o *VrfVirtualCircuit) GetSpeed() int64 {
 	if o == nil || IsNil(o.Speed) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.Speed
@@ -400,7 +400,7 @@ func (o *VrfVirtualCircuit) GetSpeed() int32 {
 
 // GetSpeedOk returns a tuple with the Speed field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *VrfVirtualCircuit) GetSpeedOk() (*int32, bool) {
+func (o *VrfVirtualCircuit) GetSpeedOk() (*int64, bool) {
 	if o == nil || IsNil(o.Speed) {
 		return nil, false
 	}
@@ -416,8 +416,8 @@ func (o *VrfVirtualCircuit) HasSpeed() bool {
 	return false
 }
 
-// SetSpeed gets a reference to the given int32 and assigns it to the Speed field.
-func (o *VrfVirtualCircuit) SetSpeed(v int32) {
+// SetSpeed gets a reference to the given int64 and assigns it to the Speed field.
+func (o *VrfVirtualCircuit) SetSpeed(v int64) {
 	o.Speed = &v
 }
 

--- a/spec/services/metalv1/oas3.patched/components/schemas/DedicatedPortCreateInput.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/DedicatedPortCreateInput.yaml
@@ -32,6 +32,7 @@ properties:
     description: |-
       A interconnection speed, in bps, mbps, or gbps. For Dedicated Ports, this can be 10Gbps or 100Gbps.
     type: integer
+    format: int64
     example: 10000000000
   tags:
     items:

--- a/spec/services/metalv1/oas3.patched/components/schemas/FabricServiceToken.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/FabricServiceToken.yaml
@@ -20,6 +20,7 @@ properties:
       of the following options, '50mbps', '200mbps', '500mbps', '1gbps', '2gbps', '5gbps' or '10gbps'. For Fabric VCs
       (Fabric Billed), this will default to 10Gbps.
     type: integer
+    format: int64
     example: 10000000000
   role:
     description: Either primary or secondary, depending on which interconnection the service token is associated to.

--- a/spec/services/metalv1/oas3.patched/components/schemas/Interconnection.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/Interconnection.yaml
@@ -50,6 +50,7 @@ properties:
   speed:
     description: For interconnections on Dedicated Ports and shared connections, this represents the interconnection's speed in bps. For Fabric VCs, this field refers to the maximum speed of the interconnection in bps. This value will default to 10Gbps for Fabric VCs (Fabric Billed).
     type: integer
+    format: int64
     example: 10000000000
   status:
     type: string

--- a/spec/services/metalv1/oas3.patched/components/schemas/InterconnectionPort.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/InterconnectionPort.yaml
@@ -32,6 +32,7 @@ properties:
     type: string
   speed:
     type: integer
+    format: int64
   link_status:
     type: string
   href:

--- a/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuit.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuit.yaml
@@ -28,6 +28,7 @@ properties:
       Fabric VCs (both Metal and Fabric Billed) that have found their corresponding Fabric connection, this is the actual speed of the interconnection that was configured when setting up the interconnection on the Fabric Portal. 
       Details on Fabric VCs are included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
     type: integer
+    format: int64
   status:
     type: string
     description: The status of a Virtual Circuit is always 'pending' on creation. The status can turn to 'Waiting on Customer VLAN' if a Metro VLAN was not set yet on the Virtual Circuit and is the last step needed for full activation. For Dedicated interconnections, as long as the Dedicated Port has been associated 

--- a/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuitCreateInput.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuitCreateInput.yaml
@@ -14,6 +14,7 @@ properties:
     description: speed can be passed as integer number representing bps speed or string
       (e.g. '52m' or '100g' or '4 gbps')
     type: integer
+    format: int64
   tags:
     items:
       type: string

--- a/spec/services/metalv1/oas3.patched/components/schemas/VrfFabricVcCreateInput.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/VrfFabricVcCreateInput.yaml
@@ -32,6 +32,7 @@ properties:
       ''50mbps'', ''200mbps'', ''500mbps'', ''1gbps'', ''2gbps'', ''5gbps'' or ''10gbps'', and is required for creation. For Fabric VCs (Fabric Billed), this field will always default to ''10gbps'' even if it is not provided.
       For example, ''500000000'', ''50m'', or' ''500mbps'' will all work as valid inputs.
     type: integer
+    format: int64
     example: 10000000000
   tags:
     items:

--- a/spec/services/metalv1/oas3.patched/components/schemas/VrfVirtualCircuit.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/VrfVirtualCircuit.yaml
@@ -38,6 +38,7 @@ properties:
   speed:
     description: integer representing bps speed
     type: integer
+    format: int64
   status:
     type: string
     description: >-

--- a/spec/services/metalv1/patches/20240116-fix-interconnection-speed.patch
+++ b/spec/services/metalv1/patches/20240116-fix-interconnection-speed.patch
@@ -1,0 +1,96 @@
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/DedicatedPortCreateInput.yaml b/spec/services/metalv1/oas3.patched/components/schemas/DedicatedPortCreateInput.yaml
+index bfd4f81..7b71723 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/DedicatedPortCreateInput.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/DedicatedPortCreateInput.yaml
+@@ -32,6 +32,7 @@ properties:
+     description: |-
+       A interconnection speed, in bps, mbps, or gbps. For Dedicated Ports, this can be 10Gbps or 100Gbps.
+     type: integer
++    format: int64
+     example: 10000000000
+   tags:
+     items:
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/Interconnection.yaml b/spec/services/metalv1/oas3.patched/components/schemas/Interconnection.yaml
+index 191a441..a663290 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/Interconnection.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/Interconnection.yaml
+@@ -50,6 +50,7 @@ properties:
+   speed:
+     description: For interconnections on Dedicated Ports and shared connections, this represents the interconnection's speed in bps. For Fabric VCs, this field refers to the maximum speed of the interconnection in bps. This value will default to 10Gbps for Fabric VCs (Fabric Billed).
+     type: integer
++    format: int64
+     example: 10000000000
+   status:
+     type: string
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/InterconnectionPort.yaml b/spec/services/metalv1/oas3.patched/components/schemas/InterconnectionPort.yaml
+index be1d7f5..0932e76 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/InterconnectionPort.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/InterconnectionPort.yaml
+@@ -32,6 +32,7 @@ properties:
+     type: string
+   speed:
+     type: integer
++    format: int64
+   link_status:
+     type: string
+   href:
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuitCreateInput.yaml b/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuitCreateInput.yaml
+index d5f9c47..5ac0d13 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuitCreateInput.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuitCreateInput.yaml
+@@ -14,6 +14,7 @@ properties:
+     description: speed can be passed as integer number representing bps speed or string
+       (e.g. '52m' or '100g' or '4 gbps')
+     type: integer
++    format: int64
+   tags:
+     items:
+       type: string
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/VrfFabricVcCreateInput.yaml b/spec/services/metalv1/oas3.patched/components/schemas/VrfFabricVcCreateInput.yaml
+index cd026b1..757e24d 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/VrfFabricVcCreateInput.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/VrfFabricVcCreateInput.yaml
+@@ -32,6 +32,7 @@ properties:
+       ''50mbps'', ''200mbps'', ''500mbps'', ''1gbps'', ''2gbps'', ''5gbps'' or ''10gbps'', and is required for creation. For Fabric VCs (Fabric Billed), this field will always default to ''10gbps'' even if it is not provided.
+       For example, ''500000000'', ''50m'', or' ''500mbps'' will all work as valid inputs.
+     type: integer
++    format: int64
+     example: 10000000000
+   tags:
+     items:
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuit.yaml b/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuit.yaml
+index fb31bbc..ba39f6d 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuit.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/VlanVirtualCircuit.yaml
+@@ -28,6 +28,7 @@ properties:
+       Fabric VCs (both Metal and Fabric Billed) that have found their corresponding Fabric connection, this is the actual speed of the interconnection that was configured when setting up the interconnection on the Fabric Portal. 
+       Details on Fabric VCs are included in the specification as a developer preview and is generally unavailable. Please contact our Support team for more details.
+     type: integer
++    format: int64
+   status:
+     type: string
+     description: The status of a Virtual Circuit is always 'pending' on creation. The status can turn to 'Waiting on Customer VLAN' if a Metro VLAN was not set yet on the Virtual Circuit and is the last step needed for full activation. For Dedicated interconnections, as long as the Dedicated Port has been associated 
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/VrfVirtualCircuit.yaml b/spec/services/metalv1/oas3.patched/components/schemas/VrfVirtualCircuit.yaml
+index 2bb47b5..5064650 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/VrfVirtualCircuit.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/VrfVirtualCircuit.yaml
+@@ -38,6 +38,7 @@ properties:
+   speed:
+     description: integer representing bps speed
+     type: integer
++    format: int64
+   status:
+     type: string
+     description: >-
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/FabricServiceToken.yaml b/spec/services/metalv1/oas3.patched/components/schemas/FabricServiceToken.yaml
+index e1559ea..54d2d97 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/FabricServiceToken.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/FabricServiceToken.yaml
+@@ -20,6 +20,7 @@ properties:
+       of the following options, '50mbps', '200mbps', '500mbps', '1gbps', '2gbps', '5gbps' or '10gbps'. For Fabric VCs
+       (Fabric Billed), this will default to 10Gbps.
+     type: integer
++    format: int64
+     example: 10000000000
+   role:
+     description: Either primary or secondary, depending on which interconnection the service token is associated to.


### PR DESCRIPTION
This is a workaround for #16; while we wait for a valid spec to be delivered, this PR introduces spec patches that appear to update the necessary fields from `int32` to `int64`.