### PR TITLE
chore: avoid apparent race condition in Make task execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ mod:
 	${GO_CMD} go mod init github.com/${GIT_ORG}/${GIT_REPO}
 	${GO_CMD} go mod tidy
 
-test:
+test: mod
 	${GO_CMD} go test -v ./...
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ generate-all:
 	done
 
 mod:
-	rm -f go.mod go.sum ${PACKAGE_PREFIX}/${PACKAGE_MAJOR}/go.mod ${PACKAGE_PREFIX}/${PACKAGE_MAJOR}/go.sum
+	for goModOrSum in $(shell set -x; find . -not \( -path ./examples -prune \) -name go.mod -o -name go.sum | sort -n); do \
+		rm -f $$goModOrSum;\
+	done
 	${GO_CMD} go mod init github.com/${GIT_ORG}/${GIT_REPO}
 	${GO_CMD} go mod tidy
 
-test: mod
+test:
 	${GO_CMD} go test -v ./...
 
 lint:

--- a/Makefile.metalv1
+++ b/Makefile.metalv1
@@ -14,7 +14,7 @@ SPEC_PATCHED_DIR=${SPEC_BASE_DIR}/${PACKAGE_NAME}/oas3.patched
 
 all: pull fetch patch generate stage
 
-generate: clean codegen remove-unused mod patch-post fmt test
+generate: clean codegen remove-unused patch-post fmt test
 
 pull:
 	${CRI} pull ${OPENAPI_IMAGE}

--- a/Makefile.metalv1
+++ b/Makefile.metalv1
@@ -14,7 +14,7 @@ SPEC_PATCHED_DIR=${SPEC_BASE_DIR}/${PACKAGE_NAME}/oas3.patched
 
 all: pull fetch patch generate stage
 
-generate: clean codegen remove-unused patch-post fmt test
+generate: clean codegen remove-unused patch-post fmt mod test
 
 pull:
 	${CRI} pull ${OPENAPI_IMAGE}
@@ -60,6 +60,4 @@ remove-unused:
 	rm -rf ${CODE_DIR}/api \
 		${CODE_DIR}/.travis.yml \
 		${CODE_DIR}/git_push.sh \
-		${CODE_DIR}/.openapi-generator \
-		${CODE_DIR}/go.mod \
-		${CODE_DIR}/go.sum
+		${CODE_DIR}/.openapi-generator

--- a/templates/Makefile.sdk
+++ b/templates/Makefile.sdk
@@ -14,7 +14,7 @@ SPEC_PATCHED_DIR=${SPEC_BASE_DIR}/${PACKAGE_NAME}/oas3.patched
 
 all: pull fetch patch generate stage
 
-generate: clean codegen remove-unused mod patch-post fmt test
+generate: clean codegen remove-unused patch-post fmt test
 
 pull:
 	${CRI} pull ${OPENAPI_IMAGE}

--- a/templates/Makefile.sdk
+++ b/templates/Makefile.sdk
@@ -14,7 +14,7 @@ SPEC_PATCHED_DIR=${SPEC_BASE_DIR}/${PACKAGE_NAME}/oas3.patched
 
 all: pull fetch patch generate stage
 
-generate: clean codegen remove-unused patch-post fmt test
+generate: clean codegen remove-unused patch-post mod fmt test
 
 pull:
 	${CRI} pull ${OPENAPI_IMAGE}
@@ -60,6 +60,4 @@ remove-unused:
 	rm -rf ${CODE_DIR}/api \
 		${CODE_DIR}/.travis.yml \
 		${CODE_DIR}/git_push.sh \
-		${CODE_DIR}/.openapi-generator \
-		${CODE_DIR}/go.mod \
-		${CODE_DIR}/go.sum
+		${CODE_DIR}/.openapi-generator


### PR DESCRIPTION
This is a weird one...somehow, switching to running Go commands in a container (#14), combined with the passage of time (worked fine for me last week, consistently doesn't this week) has broken the `make generate-all` task (and the underlying `make -f Makefile.metalv1 generate` task).  But only when I'm running locally.

In CI, `make generate-all` runs just fine (as it used to do for me locally).  Today, locally, it fails every time.  After digging through loads of console output I found this message about halfway through:

```
docker  run --rm -u 502:20 -v /Users/ctreatman/Documents/code/equinix-sdk-go:/workdir -w /workdir -e GOCACHE=/tmp/.cache golang:1.19 go mod tidy
go: warning: "all" matched no packages
```

As a result of this failed execution, the `go.mod` and `go.sum` don't declare any dependencies, which eventually causes the Go tests to fail.