### PR TITLE
fix: add missing pagination support for FindIPReservations

### DIFF
--- a/script/mark_paginated.py
+++ b/script/mark_paginated.py
@@ -37,12 +37,12 @@ if "get" in operation:
         getopparams = getop['parameters']
         for p in getopparams:
             if refkey in p:
-                if "/components/parameters/Page.yaml" in p[refkey]:
+                if ("/components/parameters/Page.yaml" in p[refkey]) :
                     schemaPathRelative = getop['responses']['200']['content']['application/json']['schema']['$ref']
                     schemaPath = schemaPathRelative.split("../")[-1]
                     twoTopDirs = ymlfile.split("/")[:2]
                     specDir = os.path.dirname(ymlfile)
-                    schemaFile = os.path.join(twoTopDirs[0], twoTopDirs[1], schemaPath)
+                    schemaFile = os.path.join(specDir, schemaPathRelative)
                     responseSchema = getYaml(schemaFile)
                     responseProps = set(responseSchema['properties'].keys())
                     oid = getop['operationId']

--- a/services/metalv1/api_ip_addresses.go
+++ b/services/metalv1/api_ip_addresses.go
@@ -645,6 +645,7 @@ type ApiFindIPReservationsRequest struct {
 	types      *[]FindIPReservationsTypesParameterInner
 	include    *[]string
 	exclude    *[]string
+	page       *int32
 	perPage    *int32
 }
 
@@ -663,6 +664,12 @@ func (r ApiFindIPReservationsRequest) Include(include []string) ApiFindIPReserva
 // Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects.
 func (r ApiFindIPReservationsRequest) Exclude(exclude []string) ApiFindIPReservationsRequest {
 	r.exclude = &exclude
+	return r
+}
+
+// Page to return
+func (r ApiFindIPReservationsRequest) Page(page int32) ApiFindIPReservationsRequest {
+	r.page = &page
 	return r
 }
 
@@ -724,6 +731,9 @@ func (a *IPAddressesApiService) FindIPReservationsExecute(r ApiFindIPReservation
 	}
 	if r.exclude != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "exclude", r.exclude, "csv")
+	}
+	if r.page != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "page", r.page, "")
 	}
 	if r.perPage != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "per_page", r.perPage, "")
@@ -826,6 +836,31 @@ func (a *IPAddressesApiService) FindIPReservationsExecute(r ApiFindIPReservation
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+// ExecuteWithPagination executes the request to fetch and return all pages of results as a single slice
+//
+//	@return IPReservationList
+func (r ApiFindIPReservationsRequest) ExecuteWithPagination() (*IPReservationList, error) {
+
+	var items IPReservationList
+
+	pageNumber := int32(1)
+
+	for {
+		page, _, err := r.Page(pageNumber).Execute()
+		if err != nil {
+			return nil, err
+		}
+
+		items.IpAddresses = append(items.IpAddresses, page.IpAddresses...)
+		if page.Meta.GetLastPage() <= page.Meta.GetCurrentPage() {
+			break
+		}
+		pageNumber = page.Meta.GetCurrentPage() + 1
+	}
+
+	return &items, nil
 }
 
 type ApiRequestIPReservationRequest struct {

--- a/services/metalv1/docs/IPAddressesApi.md
+++ b/services/metalv1/docs/IPAddressesApi.md
@@ -298,11 +298,12 @@ Name | Type | Description  | Notes
 
 ## FindIPReservations
 
-> IPReservationList FindIPReservations(ctx, id).Types(types).Include(include).Exclude(exclude).PerPage(perPage).Execute()
+> IPReservationList FindIPReservations(ctx, id).Types(types).Include(include).Exclude(exclude).Page(page).PerPage(perPage).Execute()
 
 Retrieve all ip reservations
 
 
+FindIPReservations is a paginated API operation. You can specify page number and per page parameters with `Execute`, or to fetch and return all pages of results as a single slice you can call `ExecuteWithPagination()`. `ExecuteWithPagination()`, while convenient, can significantly increase the overhead of API calls in terms of time, network utilization, and memory. Excludes can make the call more efficient by removing any unneeded nested fields that are included by default. If any of the requests fail, the list of results will be nil and the error returned will represent the failed request.
 
 ### Example
 
@@ -321,11 +322,12 @@ func main() {
     types := []openapiclient.FindIPReservationsTypesParameterInner{openapiclient.findIPReservations_types_parameter_inner("global_ipv4")} // []FindIPReservationsTypesParameterInner | Filter project IP reservations by reservation type (optional)
     include := []string{"Inner_example"} // []string | Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. (optional)
     exclude := []string{"Inner_example"} // []string | Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. (optional)
+    page := int32(56) // int32 | Page to return (optional) (default to 1)
     perPage := int32(56) // int32 | Items returned per page (optional) (default to 250)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.IPAddressesApi.FindIPReservations(context.Background(), id).Types(types).Include(include).Exclude(exclude).PerPage(perPage).Execute()
+    resp, r, err := apiClient.IPAddressesApi.FindIPReservations(context.Background(), id).Types(types).Include(include).Exclude(exclude).Page(page).PerPage(perPage).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `IPAddressesApi.FindIPReservations``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -354,6 +356,7 @@ Name | Type | Description  | Notes
  **types** | [**[]FindIPReservationsTypesParameterInner**](FindIPReservationsTypesParameterInner.md) | Filter project IP reservations by reservation type | 
  **include** | **[]string** | Nested attributes to include. Included objects will return their full attributes. Attribute names can be dotted (up to 3 levels) to included deeply nested objects. | 
  **exclude** | **[]string** | Nested attributes to exclude. Excluded objects will return only the href attribute. Attribute names can be dotted (up to 3 levels) to exclude deeply nested objects. | 
+ **page** | **int32** | Page to return | [default to 1]
  **perPage** | **int32** | Items returned per page | [default to 250]
 
 ### Return type

--- a/services/metalv1/test/api_ip_addresses_test.go
+++ b/services/metalv1/test/api_ip_addresses_test.go
@@ -78,6 +78,10 @@ func Test_metalv1_IPAddressesApiService(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, resp)
 		assert.Equal(t, 200, httpRes.StatusCode)
+
+		resp, err = apiClient.IPAddressesApi.FindIPReservations(context.Background(), id).ExecuteWithPagination()
+		require.Nil(t, err)
+		require.NotNil(t, resp)
 	})
 
 	t.Run("Test IPAddressesApiService RequestIPReservation", func(t *testing.T) {

--- a/spec/services/metalv1/oas3.patched/paths/projects/id/ips.yaml
+++ b/spec/services/metalv1/oas3.patched/paths/projects/id/ips.yaml
@@ -16,20 +16,21 @@ get:
       items:
         type: string
         enum:
-          - global_ipv4
-          - private_ipv4
-          - public_ipv4
-          - public_ipv6
-          - vrf
+        - global_ipv4
+        - private_ipv4
+        - public_ipv4
+        - public_ipv6
+        - vrf
       type: array
     style: form
   - $ref: '../../../components/parameters/Include.yaml'
   - $ref: '../../../components/parameters/Exclude.yaml'
+  - $ref: '../../../components/parameters/Page.yaml'
   - description: Items returned per page
     in: query
     name: per_page
     schema:
-      default: 250 
+      default: 250
       format: int32
       maximum: 1000
       minimum: 1
@@ -62,6 +63,7 @@ get:
   summary: Retrieve all ip reservations
   tags:
   - IPAddresses
+  x-equinix-metal-paginated-property: IpAddresses
 post:
   description: Request more IP space for a project in order to have additional IP
     addresses to assign to devices.  If the request is within the max quota, an IP

--- a/spec/services/metalv1/patches/20240119-paginate-ips.patch
+++ b/spec/services/metalv1/patches/20240119-paginate-ips.patch
@@ -1,0 +1,40 @@
+diff --git a/spec/services/metalv1/oas3.patched/paths/projects/id/ips.yaml b/spec/services/metalv1/oas3.patched/paths/projects/id/ips.yaml
+index 93765ee..db0ddf2 100644
+--- a/spec/services/metalv1/oas3.patched/paths/projects/id/ips.yaml
++++ b/spec/services/metalv1/oas3.patched/paths/projects/id/ips.yaml
+@@ -16,20 +16,21 @@ get:
+       items:
+         type: string
+         enum:
+-          - global_ipv4
+-          - private_ipv4
+-          - public_ipv4
+-          - public_ipv6
+-          - vrf
++        - global_ipv4
++        - private_ipv4
++        - public_ipv4
++        - public_ipv6
++        - vrf
+       type: array
+     style: form
+   - $ref: '../../../components/parameters/Include.yaml'
+   - $ref: '../../../components/parameters/Exclude.yaml'
++  - $ref: '../../../components/parameters/Page.yaml'
+   - description: Items returned per page
+     in: query
+     name: per_page
+     schema:
+-      default: 250 
++      default: 250
+       format: int32
+       maximum: 1000
+       minimum: 1
+@@ -62,6 +63,7 @@ get:
+   summary: Retrieve all ip reservations
+   tags:
+   - IPAddresses
++  x-equinix-metal-paginated-property: IpAddresses
+ post:
+   description: Request more IP space for a project in order to have additional IP
+     addresses to assign to devices.  If the request is within the max quota, an IP


### PR DESCRIPTION
This works around #18 by patching the local spec to define the `page` parameter for the `findIPReservations` endpoint.