### PR TITLE
feat: update virtual networks to reference resource schemas instead of href

### DIFF
--- a/services/metalv1/docs/Port.md
+++ b/services/metalv1/docs/Port.md
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 **Type** | Pointer to [**PortType**](PortType.md) |  | [optional] 
 **NetworkType** | Pointer to [**PortNetworkType**](PortNetworkType.md) |  | [optional] 
 **NativeVirtualNetwork** | Pointer to [**VirtualNetwork**](VirtualNetwork.md) |  | [optional] 
-**VirtualNetworks** | Pointer to [**[]Href**](Href.md) |  | [optional] 
+**VirtualNetworks** | Pointer to [**[]VirtualNetwork**](VirtualNetwork.md) |  | [optional] 
 
 ## Methods
 
@@ -261,20 +261,20 @@ HasNativeVirtualNetwork returns a boolean if a field has been set.
 
 ### GetVirtualNetworks
 
-`func (o *Port) GetVirtualNetworks() []Href`
+`func (o *Port) GetVirtualNetworks() []VirtualNetwork`
 
 GetVirtualNetworks returns the VirtualNetworks field if non-nil, zero value otherwise.
 
 ### GetVirtualNetworksOk
 
-`func (o *Port) GetVirtualNetworksOk() (*[]Href, bool)`
+`func (o *Port) GetVirtualNetworksOk() (*[]VirtualNetwork, bool)`
 
 GetVirtualNetworksOk returns a tuple with the VirtualNetworks field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetVirtualNetworks
 
-`func (o *Port) SetVirtualNetworks(v []Href)`
+`func (o *Port) SetVirtualNetworks(v []VirtualNetwork)`
 
 SetVirtualNetworks sets VirtualNetworks field to given value.
 

--- a/services/metalv1/docs/VirtualNetwork.md
+++ b/services/metalv1/docs/VirtualNetwork.md
@@ -4,16 +4,16 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**AssignedTo** | Pointer to [**Href**](Href.md) |  | [optional] 
+**AssignedTo** | Pointer to [**Project**](Project.md) |  | [optional] 
 **AssignedToVirtualCircuit** | Pointer to **bool** | True if the virtual network is attached to a virtual circuit. False if not. | [optional] 
 **Description** | Pointer to **string** |  | [optional] 
 **Facility** | Pointer to [**Href**](Href.md) |  | [optional] 
 **Href** | Pointer to **string** |  | [optional] 
 **CreatedAt** | Pointer to **time.Time** |  | [optional] 
 **Id** | Pointer to **string** |  | [optional] 
-**Instances** | Pointer to [**[]Href**](Href.md) | A list of instances with ports currently associated to this Virtual Network. | [optional] 
+**Instances** | Pointer to [**[]Device**](Device.md) | A list of instances with ports currently associated to this Virtual Network. | [optional] 
 **MetalGateways** | Pointer to [**[]MetalGatewayLite**](MetalGatewayLite.md) | A list of metal gateways currently associated to this Virtual Network. | [optional] 
-**Metro** | Pointer to [**Href**](Href.md) |  | [optional] 
+**Metro** | Pointer to [**Metro**](Metro.md) |  | [optional] 
 **MetroCode** | Pointer to **string** | The Metro code of the metro in which this Virtual Network is defined. | [optional] 
 **Vxlan** | Pointer to **int32** |  | [optional] 
 **Tags** | Pointer to **[]string** |  | [optional] 
@@ -39,20 +39,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetAssignedTo
 
-`func (o *VirtualNetwork) GetAssignedTo() Href`
+`func (o *VirtualNetwork) GetAssignedTo() Project`
 
 GetAssignedTo returns the AssignedTo field if non-nil, zero value otherwise.
 
 ### GetAssignedToOk
 
-`func (o *VirtualNetwork) GetAssignedToOk() (*Href, bool)`
+`func (o *VirtualNetwork) GetAssignedToOk() (*Project, bool)`
 
 GetAssignedToOk returns a tuple with the AssignedTo field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetAssignedTo
 
-`func (o *VirtualNetwork) SetAssignedTo(v Href)`
+`func (o *VirtualNetwork) SetAssignedTo(v Project)`
 
 SetAssignedTo sets AssignedTo field to given value.
 
@@ -214,20 +214,20 @@ HasId returns a boolean if a field has been set.
 
 ### GetInstances
 
-`func (o *VirtualNetwork) GetInstances() []Href`
+`func (o *VirtualNetwork) GetInstances() []Device`
 
 GetInstances returns the Instances field if non-nil, zero value otherwise.
 
 ### GetInstancesOk
 
-`func (o *VirtualNetwork) GetInstancesOk() (*[]Href, bool)`
+`func (o *VirtualNetwork) GetInstancesOk() (*[]Device, bool)`
 
 GetInstancesOk returns a tuple with the Instances field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetInstances
 
-`func (o *VirtualNetwork) SetInstances(v []Href)`
+`func (o *VirtualNetwork) SetInstances(v []Device)`
 
 SetInstances sets Instances field to given value.
 
@@ -264,20 +264,20 @@ HasMetalGateways returns a boolean if a field has been set.
 
 ### GetMetro
 
-`func (o *VirtualNetwork) GetMetro() Href`
+`func (o *VirtualNetwork) GetMetro() Metro`
 
 GetMetro returns the Metro field if non-nil, zero value otherwise.
 
 ### GetMetroOk
 
-`func (o *VirtualNetwork) GetMetroOk() (*Href, bool)`
+`func (o *VirtualNetwork) GetMetroOk() (*Metro, bool)`
 
 GetMetroOk returns a tuple with the Metro field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetMetro
 
-`func (o *VirtualNetwork) SetMetro(v Href)`
+`func (o *VirtualNetwork) SetMetro(v Metro)`
 
 SetMetro sets Metro field to given value.
 

--- a/services/metalv1/model_port.go
+++ b/services/metalv1/model_port.go
@@ -30,7 +30,7 @@ type Port struct {
 	Type                      *PortType        `json:"type,omitempty"`
 	NetworkType               *PortNetworkType `json:"network_type,omitempty"`
 	NativeVirtualNetwork      *VirtualNetwork  `json:"native_virtual_network,omitempty"`
-	VirtualNetworks           []Href           `json:"virtual_networks,omitempty"`
+	VirtualNetworks           []VirtualNetwork `json:"virtual_networks,omitempty"`
 	AdditionalProperties      map[string]interface{}
 }
 
@@ -342,9 +342,9 @@ func (o *Port) SetNativeVirtualNetwork(v VirtualNetwork) {
 }
 
 // GetVirtualNetworks returns the VirtualNetworks field value if set, zero value otherwise.
-func (o *Port) GetVirtualNetworks() []Href {
+func (o *Port) GetVirtualNetworks() []VirtualNetwork {
 	if o == nil || IsNil(o.VirtualNetworks) {
-		var ret []Href
+		var ret []VirtualNetwork
 		return ret
 	}
 	return o.VirtualNetworks
@@ -352,7 +352,7 @@ func (o *Port) GetVirtualNetworks() []Href {
 
 // GetVirtualNetworksOk returns a tuple with the VirtualNetworks field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Port) GetVirtualNetworksOk() ([]Href, bool) {
+func (o *Port) GetVirtualNetworksOk() ([]VirtualNetwork, bool) {
 	if o == nil || IsNil(o.VirtualNetworks) {
 		return nil, false
 	}
@@ -368,8 +368,8 @@ func (o *Port) HasVirtualNetworks() bool {
 	return false
 }
 
-// SetVirtualNetworks gets a reference to the given []Href and assigns it to the VirtualNetworks field.
-func (o *Port) SetVirtualNetworks(v []Href) {
+// SetVirtualNetworks gets a reference to the given []VirtualNetwork and assigns it to the VirtualNetworks field.
+func (o *Port) SetVirtualNetworks(v []VirtualNetwork) {
 	o.VirtualNetworks = v
 }
 

--- a/services/metalv1/model_virtual_network.go
+++ b/services/metalv1/model_virtual_network.go
@@ -21,7 +21,7 @@ var _ MappedNullable = &VirtualNetwork{}
 
 // VirtualNetwork struct for VirtualNetwork
 type VirtualNetwork struct {
-	AssignedTo *Href `json:"assigned_to,omitempty"`
+	AssignedTo *Project `json:"assigned_to,omitempty"`
 	// True if the virtual network is attached to a virtual circuit. False if not.
 	AssignedToVirtualCircuit *bool      `json:"assigned_to_virtual_circuit,omitempty"`
 	Description              *string    `json:"description,omitempty"`
@@ -30,10 +30,10 @@ type VirtualNetwork struct {
 	CreatedAt                *time.Time `json:"created_at,omitempty"`
 	Id                       *string    `json:"id,omitempty"`
 	// A list of instances with ports currently associated to this Virtual Network.
-	Instances []Href `json:"instances,omitempty"`
+	Instances []Device `json:"instances,omitempty"`
 	// A list of metal gateways currently associated to this Virtual Network.
 	MetalGateways []MetalGatewayLite `json:"metal_gateways,omitempty"`
-	Metro         *Href              `json:"metro,omitempty"`
+	Metro         *Metro             `json:"metro,omitempty"`
 	// The Metro code of the metro in which this Virtual Network is defined.
 	MetroCode            *string  `json:"metro_code,omitempty"`
 	Vxlan                *int32   `json:"vxlan,omitempty"`
@@ -61,9 +61,9 @@ func NewVirtualNetworkWithDefaults() *VirtualNetwork {
 }
 
 // GetAssignedTo returns the AssignedTo field value if set, zero value otherwise.
-func (o *VirtualNetwork) GetAssignedTo() Href {
+func (o *VirtualNetwork) GetAssignedTo() Project {
 	if o == nil || IsNil(o.AssignedTo) {
-		var ret Href
+		var ret Project
 		return ret
 	}
 	return *o.AssignedTo
@@ -71,7 +71,7 @@ func (o *VirtualNetwork) GetAssignedTo() Href {
 
 // GetAssignedToOk returns a tuple with the AssignedTo field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *VirtualNetwork) GetAssignedToOk() (*Href, bool) {
+func (o *VirtualNetwork) GetAssignedToOk() (*Project, bool) {
 	if o == nil || IsNil(o.AssignedTo) {
 		return nil, false
 	}
@@ -87,8 +87,8 @@ func (o *VirtualNetwork) HasAssignedTo() bool {
 	return false
 }
 
-// SetAssignedTo gets a reference to the given Href and assigns it to the AssignedTo field.
-func (o *VirtualNetwork) SetAssignedTo(v Href) {
+// SetAssignedTo gets a reference to the given Project and assigns it to the AssignedTo field.
+func (o *VirtualNetwork) SetAssignedTo(v Project) {
 	o.AssignedTo = &v
 }
 
@@ -285,9 +285,9 @@ func (o *VirtualNetwork) SetId(v string) {
 }
 
 // GetInstances returns the Instances field value if set, zero value otherwise.
-func (o *VirtualNetwork) GetInstances() []Href {
+func (o *VirtualNetwork) GetInstances() []Device {
 	if o == nil || IsNil(o.Instances) {
-		var ret []Href
+		var ret []Device
 		return ret
 	}
 	return o.Instances
@@ -295,7 +295,7 @@ func (o *VirtualNetwork) GetInstances() []Href {
 
 // GetInstancesOk returns a tuple with the Instances field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *VirtualNetwork) GetInstancesOk() ([]Href, bool) {
+func (o *VirtualNetwork) GetInstancesOk() ([]Device, bool) {
 	if o == nil || IsNil(o.Instances) {
 		return nil, false
 	}
@@ -311,8 +311,8 @@ func (o *VirtualNetwork) HasInstances() bool {
 	return false
 }
 
-// SetInstances gets a reference to the given []Href and assigns it to the Instances field.
-func (o *VirtualNetwork) SetInstances(v []Href) {
+// SetInstances gets a reference to the given []Device and assigns it to the Instances field.
+func (o *VirtualNetwork) SetInstances(v []Device) {
 	o.Instances = v
 }
 
@@ -349,9 +349,9 @@ func (o *VirtualNetwork) SetMetalGateways(v []MetalGatewayLite) {
 }
 
 // GetMetro returns the Metro field value if set, zero value otherwise.
-func (o *VirtualNetwork) GetMetro() Href {
+func (o *VirtualNetwork) GetMetro() Metro {
 	if o == nil || IsNil(o.Metro) {
-		var ret Href
+		var ret Metro
 		return ret
 	}
 	return *o.Metro
@@ -359,7 +359,7 @@ func (o *VirtualNetwork) GetMetro() Href {
 
 // GetMetroOk returns a tuple with the Metro field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *VirtualNetwork) GetMetroOk() (*Href, bool) {
+func (o *VirtualNetwork) GetMetroOk() (*Metro, bool) {
 	if o == nil || IsNil(o.Metro) {
 		return nil, false
 	}
@@ -375,8 +375,8 @@ func (o *VirtualNetwork) HasMetro() bool {
 	return false
 }
 
-// SetMetro gets a reference to the given Href and assigns it to the Metro field.
-func (o *VirtualNetwork) SetMetro(v Href) {
+// SetMetro gets a reference to the given Metro and assigns it to the Metro field.
+func (o *VirtualNetwork) SetMetro(v Metro) {
 	o.Metro = &v
 }
 

--- a/spec/services/metalv1/oas3.patched/components/schemas/Port.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/Port.yaml
@@ -35,6 +35,6 @@ properties:
     $ref: './VirtualNetwork.yaml'
   virtual_networks:
     items:
-      $ref: './Href.yaml'
+      $ref: './VirtualNetwork.yaml'
     type: array
 type: object

--- a/spec/services/metalv1/oas3.patched/components/schemas/VirtualNetwork.yaml
+++ b/spec/services/metalv1/oas3.patched/components/schemas/VirtualNetwork.yaml
@@ -1,6 +1,6 @@
 properties:
   assigned_to:
-    $ref: './Href.yaml'
+    $ref: './Project.yaml'
   assigned_to_virtual_circuit:
     description: True if the virtual network is attached to a virtual circuit. False
       if not.
@@ -21,7 +21,7 @@ properties:
     description: A list of instances with ports currently associated to this Virtual
       Network.
     items:
-      $ref: './Href.yaml'
+      $ref: './Device.yaml'
     type: array
   metal_gateways:
     description: A list of metal gateways currently associated to this Virtual Network.
@@ -29,7 +29,7 @@ properties:
       $ref: './MetalGatewayLite.yaml'
     type: array
   metro:
-    $ref: './Href.yaml'
+    $ref: './Metro.yaml'
   metro_code:
     description: The Metro code of the metro in which this Virtual Network is defined.
     type: string

--- a/spec/services/metalv1/patches/20240125-port-virtual-network.patch
+++ b/spec/services/metalv1/patches/20240125-port-virtual-network.patch
@@ -1,0 +1,12 @@
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/Port.yaml b/spec/services/metalv1/oas3.patched/components/schemas/Port.yaml
+index bceaf31..e232c6d 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/Port.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/Port.yaml
+@@ -35,6 +35,6 @@ properties:
+     $ref: './VirtualNetwork.yaml'
+   virtual_networks:
+     items:
+-      $ref: './Href.yaml'
++      $ref: './VirtualNetwork.yaml'
+     type: array
+ type: object

--- a/spec/services/metalv1/patches/20240125-virtual-network-model-refs.patch
+++ b/spec/services/metalv1/patches/20240125-virtual-network-model-refs.patch
@@ -1,0 +1,30 @@
+diff --git a/spec/services/metalv1/oas3.patched/components/schemas/VirtualNetwork.yaml b/spec/services/metalv1/oas3.patched/components/schemas/VirtualNetwork.yaml
+index bae14ae..311670d 100644
+--- a/spec/services/metalv1/oas3.patched/components/schemas/VirtualNetwork.yaml
++++ b/spec/services/metalv1/oas3.patched/components/schemas/VirtualNetwork.yaml
+@@ -1,6 +1,6 @@
+ properties:
+   assigned_to:
+-    $ref: './Href.yaml'
++    $ref: './Project.yaml'
+   assigned_to_virtual_circuit:
+     description: True if the virtual network is attached to a virtual circuit. False
+       if not.
+@@ -21,7 +21,7 @@ properties:
+     description: A list of instances with ports currently associated to this Virtual
+       Network.
+     items:
+-      $ref: './Href.yaml'
++      $ref: './Device.yaml'
+     type: array
+   metal_gateways:
+     description: A list of metal gateways currently associated to this Virtual Network.
+@@ -29,7 +29,7 @@ properties:
+       $ref: './MetalGatewayLite.yaml'
+     type: array
+   metro:
+-    $ref: './Href.yaml'
++    $ref: './Metro.yaml'
+   metro_code:
+     description: The Metro code of the metro in which this Virtual Network is defined.
+     type: string


### PR DESCRIPTION
While [converting the `metal_vlan` Terraform resource and datasource to this SDK](https://github.com/equinix/terraform-provider-equinix/pull/541), a number of issues were uncovered in the `VirtualNetwork` schema.  A number of properties relevant to virtual networks were declared as `$ref`s to the `Href` component, which only has one named property, `href`.  References to the `Href` component make it difficult to access attributes of nested resources; this updates those references to point to more specific components instead.