### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+#
+*                       @equinix/governor-devrel-engineering
+*metal*                 @equinix/governor-metal-client-interfaces


### PR DESCRIPTION
This adds an initial `CODEOWNERS` file so we can establish patterns around code ownership and review.  As more teams are onboarded to this SDK, we can update the `CODEOWNERS` file to ensure that those teams are kept in the loop when relevant code changes.