### PR TITLE
fix: Correct Fabricv4 API Spec via patching to use valid any type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/equinix/equinix-sdk-go
 
 go 1.19
 
-require github.com/stretchr/testify v1.8.4
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/services/fabricv4/docs/CloudRouterChangeOperation.md
+++ b/services/fabricv4/docs/CloudRouterChangeOperation.md
@@ -6,13 +6,13 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Op** | [**PrecisionTimeChangeOperationOp**](PrecisionTimeChangeOperationOp.md) |  | 
 **Path** | **string** | path inside document leading to updated parameter | 
-**Value** | **map[string]interface{}** | new value for updated parameter | 
+**Value** | **interface{}** | new value for updated parameter | 
 
 ## Methods
 
 ### NewCloudRouterChangeOperation
 
-`func NewCloudRouterChangeOperation(op PrecisionTimeChangeOperationOp, path string, value map[string]interface{}, ) *CloudRouterChangeOperation`
+`func NewCloudRouterChangeOperation(op PrecisionTimeChangeOperationOp, path string, value interface{}, ) *CloudRouterChangeOperation`
 
 NewCloudRouterChangeOperation instantiates a new CloudRouterChangeOperation object
 This constructor will assign default values to properties that have it defined,
@@ -69,24 +69,34 @@ SetPath sets Path field to given value.
 
 ### GetValue
 
-`func (o *CloudRouterChangeOperation) GetValue() map[string]interface{}`
+`func (o *CloudRouterChangeOperation) GetValue() interface{}`
 
 GetValue returns the Value field if non-nil, zero value otherwise.
 
 ### GetValueOk
 
-`func (o *CloudRouterChangeOperation) GetValueOk() (*map[string]interface{}, bool)`
+`func (o *CloudRouterChangeOperation) GetValueOk() (*interface{}, bool)`
 
 GetValueOk returns a tuple with the Value field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetValue
 
-`func (o *CloudRouterChangeOperation) SetValue(v map[string]interface{})`
+`func (o *CloudRouterChangeOperation) SetValue(v interface{})`
 
 SetValue sets Value field to given value.
 
 
+### SetValueNil
+
+`func (o *CloudRouterChangeOperation) SetValueNil(b bool)`
+
+ SetValueNil sets the value for Value to be an explicit nil
+
+### UnsetValue
+`func (o *CloudRouterChangeOperation) UnsetValue()`
+
+UnsetValue ensures that no value is present for Value, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/services/fabricv4/docs/CloudRoutersApi.md
+++ b/services/fabricv4/docs/CloudRoutersApi.md
@@ -663,7 +663,7 @@ import (
 
 func main() {
 	routerId := "38400000-8cf0-11bd-b23e-10b96e4ef00d" // string | Cloud Router UUID
-	cloudRouterChangeOperation := []openapiclient.CloudRouterChangeOperation{*openapiclient.NewCloudRouterChangeOperation(openapiclient.precisionTimeChangeOperation_op("replace"), "Path_example", map[string]interface{}(123))} // []CloudRouterChangeOperation | 
+	cloudRouterChangeOperation := []openapiclient.CloudRouterChangeOperation{*openapiclient.NewCloudRouterChangeOperation(openapiclient.precisionTimeChangeOperation_op("replace"), "Path_example", interface{}(123))} // []CloudRouterChangeOperation | 
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/services/fabricv4/docs/ConnectionChangeOperation.md
+++ b/services/fabricv4/docs/ConnectionChangeOperation.md
@@ -6,13 +6,13 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Op** | **string** | Handy shortcut for operation name | 
 **Path** | **string** | path inside document leading to updated parameter | 
-**Value** | **map[string]interface{}** | new value for updated parameter | 
+**Value** | **interface{}** | new value for updated parameter | 
 
 ## Methods
 
 ### NewConnectionChangeOperation
 
-`func NewConnectionChangeOperation(op string, path string, value map[string]interface{}, ) *ConnectionChangeOperation`
+`func NewConnectionChangeOperation(op string, path string, value interface{}, ) *ConnectionChangeOperation`
 
 NewConnectionChangeOperation instantiates a new ConnectionChangeOperation object
 This constructor will assign default values to properties that have it defined,
@@ -69,24 +69,34 @@ SetPath sets Path field to given value.
 
 ### GetValue
 
-`func (o *ConnectionChangeOperation) GetValue() map[string]interface{}`
+`func (o *ConnectionChangeOperation) GetValue() interface{}`
 
 GetValue returns the Value field if non-nil, zero value otherwise.
 
 ### GetValueOk
 
-`func (o *ConnectionChangeOperation) GetValueOk() (*map[string]interface{}, bool)`
+`func (o *ConnectionChangeOperation) GetValueOk() (*interface{}, bool)`
 
 GetValueOk returns a tuple with the Value field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetValue
 
-`func (o *ConnectionChangeOperation) SetValue(v map[string]interface{})`
+`func (o *ConnectionChangeOperation) SetValue(v interface{})`
 
 SetValue sets Value field to given value.
 
 
+### SetValueNil
+
+`func (o *ConnectionChangeOperation) SetValueNil(b bool)`
+
+ SetValueNil sets the value for Value to be an explicit nil
+
+### UnsetValue
+`func (o *ConnectionChangeOperation) UnsetValue()`
+
+UnsetValue ensures that no value is present for Value, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/services/fabricv4/docs/ConnectionsApi.md
+++ b/services/fabricv4/docs/ConnectionsApi.md
@@ -382,7 +382,7 @@ import (
 
 func main() {
 	connectionId := "connectionId_example" // string | Connection Id
-	connectionChangeOperation := []openapiclient.ConnectionChangeOperation{*openapiclient.NewConnectionChangeOperation("add", "/ipv6", map[string]interface{}(123))} // []ConnectionChangeOperation | 
+	connectionChangeOperation := []openapiclient.ConnectionChangeOperation{*openapiclient.NewConnectionChangeOperation("add", "/ipv6", interface{}(123))} // []ConnectionChangeOperation | 
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/services/fabricv4/docs/NetworkChangeOperation.md
+++ b/services/fabricv4/docs/NetworkChangeOperation.md
@@ -6,13 +6,13 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Op** | [**PrecisionTimeChangeOperationOp**](PrecisionTimeChangeOperationOp.md) |  | 
 **Path** | **string** | path inside document leading to updated parameter | 
-**Value** | **map[string]interface{}** | new value for updated parameter | 
+**Value** | **interface{}** | new value for updated parameter | 
 
 ## Methods
 
 ### NewNetworkChangeOperation
 
-`func NewNetworkChangeOperation(op PrecisionTimeChangeOperationOp, path string, value map[string]interface{}, ) *NetworkChangeOperation`
+`func NewNetworkChangeOperation(op PrecisionTimeChangeOperationOp, path string, value interface{}, ) *NetworkChangeOperation`
 
 NewNetworkChangeOperation instantiates a new NetworkChangeOperation object
 This constructor will assign default values to properties that have it defined,
@@ -69,24 +69,34 @@ SetPath sets Path field to given value.
 
 ### GetValue
 
-`func (o *NetworkChangeOperation) GetValue() map[string]interface{}`
+`func (o *NetworkChangeOperation) GetValue() interface{}`
 
 GetValue returns the Value field if non-nil, zero value otherwise.
 
 ### GetValueOk
 
-`func (o *NetworkChangeOperation) GetValueOk() (*map[string]interface{}, bool)`
+`func (o *NetworkChangeOperation) GetValueOk() (*interface{}, bool)`
 
 GetValueOk returns a tuple with the Value field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetValue
 
-`func (o *NetworkChangeOperation) SetValue(v map[string]interface{})`
+`func (o *NetworkChangeOperation) SetValue(v interface{})`
 
 SetValue sets Value field to given value.
 
 
+### SetValueNil
+
+`func (o *NetworkChangeOperation) SetValueNil(b bool)`
+
+ SetValueNil sets the value for Value to be an explicit nil
+
+### UnsetValue
+`func (o *NetworkChangeOperation) UnsetValue()`
+
+UnsetValue ensures that no value is present for Value, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/services/fabricv4/docs/NetworksApi.md
+++ b/services/fabricv4/docs/NetworksApi.md
@@ -522,7 +522,7 @@ import (
 
 func main() {
 	networkId := "38400000-8cf0-11bd-b23e-10b96e4ef00d" // string | Network UUID
-	networkChangeOperation := []openapiclient.NetworkChangeOperation{*openapiclient.NewNetworkChangeOperation(openapiclient.precisionTimeChangeOperation_op("replace"), "/name", map[string]interface{}(123))} // []NetworkChangeOperation | 
+	networkChangeOperation := []openapiclient.NetworkChangeOperation{*openapiclient.NewNetworkChangeOperation(openapiclient.precisionTimeChangeOperation_op("replace"), "/name", interface{}(123))} // []NetworkChangeOperation | 
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/services/fabricv4/docs/PrecisionTimeApi.md
+++ b/services/fabricv4/docs/PrecisionTimeApi.md
@@ -239,7 +239,7 @@ import (
 
 func main() {
 	serviceId := "38400000-8cf0-11bd-b23e-10b96e4ef00d" // string | Service UUID
-	precisionTimeChangeOperation := []openapiclient.PrecisionTimeChangeOperation{*openapiclient.NewPrecisionTimeChangeOperation(openapiclient.precisionTimeChangeOperation_op("replace"), openapiclient.precisionTimeChangeOperation_path("/ipv4"), map[string]interface{}(123))} // []PrecisionTimeChangeOperation | 
+	precisionTimeChangeOperation := []openapiclient.PrecisionTimeChangeOperation{*openapiclient.NewPrecisionTimeChangeOperation(openapiclient.precisionTimeChangeOperation_op("replace"), openapiclient.precisionTimeChangeOperation_path("/ipv4"), interface{}(123))} // []PrecisionTimeChangeOperation | 
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/services/fabricv4/docs/PrecisionTimeChangeOperation.md
+++ b/services/fabricv4/docs/PrecisionTimeChangeOperation.md
@@ -6,13 +6,13 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Op** | [**PrecisionTimeChangeOperationOp**](PrecisionTimeChangeOperationOp.md) |  | 
 **Path** | [**PrecisionTimeChangeOperationPath**](PrecisionTimeChangeOperationPath.md) |  | 
-**Value** | **map[string]interface{}** | new value for updated parameter | 
+**Value** | **interface{}** | new value for updated parameter | 
 
 ## Methods
 
 ### NewPrecisionTimeChangeOperation
 
-`func NewPrecisionTimeChangeOperation(op PrecisionTimeChangeOperationOp, path PrecisionTimeChangeOperationPath, value map[string]interface{}, ) *PrecisionTimeChangeOperation`
+`func NewPrecisionTimeChangeOperation(op PrecisionTimeChangeOperationOp, path PrecisionTimeChangeOperationPath, value interface{}, ) *PrecisionTimeChangeOperation`
 
 NewPrecisionTimeChangeOperation instantiates a new PrecisionTimeChangeOperation object
 This constructor will assign default values to properties that have it defined,
@@ -69,24 +69,34 @@ SetPath sets Path field to given value.
 
 ### GetValue
 
-`func (o *PrecisionTimeChangeOperation) GetValue() map[string]interface{}`
+`func (o *PrecisionTimeChangeOperation) GetValue() interface{}`
 
 GetValue returns the Value field if non-nil, zero value otherwise.
 
 ### GetValueOk
 
-`func (o *PrecisionTimeChangeOperation) GetValueOk() (*map[string]interface{}, bool)`
+`func (o *PrecisionTimeChangeOperation) GetValueOk() (*interface{}, bool)`
 
 GetValueOk returns a tuple with the Value field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetValue
 
-`func (o *PrecisionTimeChangeOperation) SetValue(v map[string]interface{})`
+`func (o *PrecisionTimeChangeOperation) SetValue(v interface{})`
 
 SetValue sets Value field to given value.
 
 
+### SetValueNil
+
+`func (o *PrecisionTimeChangeOperation) SetValueNil(b bool)`
+
+ SetValueNil sets the value for Value to be an explicit nil
+
+### UnsetValue
+`func (o *PrecisionTimeChangeOperation) UnsetValue()`
+
+UnsetValue ensures that no value is present for Value, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/services/fabricv4/docs/RoutingProtocolsApi.md
+++ b/services/fabricv4/docs/RoutingProtocolsApi.md
@@ -713,7 +713,7 @@ import (
 func main() {
 	routingProtocolId := "38400000-8cf0-11bd-b23e-10b96e4ef00d" // string | Routing Protocol Id
 	connectionId := "connectionId_example" // string | Connection Id
-	connectionChangeOperation := []openapiclient.ConnectionChangeOperation{*openapiclient.NewConnectionChangeOperation("add", "/ipv6", map[string]interface{}(123))} // []ConnectionChangeOperation | 
+	connectionChangeOperation := []openapiclient.ConnectionChangeOperation{*openapiclient.NewConnectionChangeOperation("add", "/ipv6", interface{}(123))} // []ConnectionChangeOperation | 
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/services/fabricv4/docs/ServiceTokenChangeOperation.md
+++ b/services/fabricv4/docs/ServiceTokenChangeOperation.md
@@ -6,13 +6,13 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Op** | [**PrecisionTimeChangeOperationOp**](PrecisionTimeChangeOperationOp.md) |  | 
 **Path** | **string** | path inside document leading to updated parameter | 
-**Value** | **map[string]interface{}** | new value for updated parameter | 
+**Value** | **interface{}** | new value for updated parameter | 
 
 ## Methods
 
 ### NewServiceTokenChangeOperation
 
-`func NewServiceTokenChangeOperation(op PrecisionTimeChangeOperationOp, path string, value map[string]interface{}, ) *ServiceTokenChangeOperation`
+`func NewServiceTokenChangeOperation(op PrecisionTimeChangeOperationOp, path string, value interface{}, ) *ServiceTokenChangeOperation`
 
 NewServiceTokenChangeOperation instantiates a new ServiceTokenChangeOperation object
 This constructor will assign default values to properties that have it defined,
@@ -69,24 +69,34 @@ SetPath sets Path field to given value.
 
 ### GetValue
 
-`func (o *ServiceTokenChangeOperation) GetValue() map[string]interface{}`
+`func (o *ServiceTokenChangeOperation) GetValue() interface{}`
 
 GetValue returns the Value field if non-nil, zero value otherwise.
 
 ### GetValueOk
 
-`func (o *ServiceTokenChangeOperation) GetValueOk() (*map[string]interface{}, bool)`
+`func (o *ServiceTokenChangeOperation) GetValueOk() (*interface{}, bool)`
 
 GetValueOk returns a tuple with the Value field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetValue
 
-`func (o *ServiceTokenChangeOperation) SetValue(v map[string]interface{})`
+`func (o *ServiceTokenChangeOperation) SetValue(v interface{})`
 
 SetValue sets Value field to given value.
 
 
+### SetValueNil
+
+`func (o *ServiceTokenChangeOperation) SetValueNil(b bool)`
+
+ SetValueNil sets the value for Value to be an explicit nil
+
+### UnsetValue
+`func (o *ServiceTokenChangeOperation) UnsetValue()`
+
+UnsetValue ensures that no value is present for Value, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/services/fabricv4/docs/ServiceTokensApi.md
+++ b/services/fabricv4/docs/ServiceTokensApi.md
@@ -446,7 +446,7 @@ import (
 
 func main() {
 	serviceTokenId := "38400000-8cf0-11bd-b23e-10b96e4ef00d" // string | Service Token UUID
-	serviceTokenChangeOperation := []openapiclient.ServiceTokenChangeOperation{*openapiclient.NewServiceTokenChangeOperation(openapiclient.precisionTimeChangeOperation_op("replace"), "/expirationDateTime", map[string]interface{}(123))} // []ServiceTokenChangeOperation | 
+	serviceTokenChangeOperation := []openapiclient.ServiceTokenChangeOperation{*openapiclient.NewServiceTokenChangeOperation(openapiclient.precisionTimeChangeOperation_op("replace"), "/expirationDateTime", interface{}(123))} // []ServiceTokenChangeOperation | 
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/services/fabricv4/model_cloud_router_change_operation.go
+++ b/services/fabricv4/model_cloud_router_change_operation.go
@@ -25,7 +25,7 @@ type CloudRouterChangeOperation struct {
 	// path inside document leading to updated parameter
 	Path string `json:"path"`
 	// new value for updated parameter
-	Value                map[string]interface{} `json:"value"`
+	Value                interface{} `json:"value"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -35,7 +35,7 @@ type _CloudRouterChangeOperation CloudRouterChangeOperation
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCloudRouterChangeOperation(op PrecisionTimeChangeOperationOp, path string, value map[string]interface{}) *CloudRouterChangeOperation {
+func NewCloudRouterChangeOperation(op PrecisionTimeChangeOperationOp, path string, value interface{}) *CloudRouterChangeOperation {
 	this := CloudRouterChangeOperation{}
 	this.Op = op
 	this.Path = path
@@ -100,9 +100,10 @@ func (o *CloudRouterChangeOperation) SetPath(v string) {
 }
 
 // GetValue returns the Value field value
-func (o *CloudRouterChangeOperation) GetValue() map[string]interface{} {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *CloudRouterChangeOperation) GetValue() interface{} {
 	if o == nil {
-		var ret map[string]interface{}
+		var ret interface{}
 		return ret
 	}
 
@@ -111,15 +112,16 @@ func (o *CloudRouterChangeOperation) GetValue() map[string]interface{} {
 
 // GetValueOk returns a tuple with the Value field value
 // and a boolean to check if the value has been set.
-func (o *CloudRouterChangeOperation) GetValueOk() (map[string]interface{}, bool) {
-	if o == nil {
-		return map[string]interface{}{}, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *CloudRouterChangeOperation) GetValueOk() (*interface{}, bool) {
+	if o == nil || IsNil(o.Value) {
+		return nil, false
 	}
-	return o.Value, true
+	return &o.Value, true
 }
 
 // SetValue sets field value
-func (o *CloudRouterChangeOperation) SetValue(v map[string]interface{}) {
+func (o *CloudRouterChangeOperation) SetValue(v interface{}) {
 	o.Value = v
 }
 
@@ -135,7 +137,9 @@ func (o CloudRouterChangeOperation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["op"] = o.Op
 	toSerialize["path"] = o.Path
-	toSerialize["value"] = o.Value
+	if o.Value != nil {
+		toSerialize["value"] = o.Value
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value

--- a/services/fabricv4/model_connection_change_operation.go
+++ b/services/fabricv4/model_connection_change_operation.go
@@ -26,7 +26,7 @@ type ConnectionChangeOperation struct {
 	// path inside document leading to updated parameter
 	Path string `json:"path"`
 	// new value for updated parameter
-	Value                map[string]interface{} `json:"value"`
+	Value                interface{} `json:"value"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -36,7 +36,7 @@ type _ConnectionChangeOperation ConnectionChangeOperation
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewConnectionChangeOperation(op string, path string, value map[string]interface{}) *ConnectionChangeOperation {
+func NewConnectionChangeOperation(op string, path string, value interface{}) *ConnectionChangeOperation {
 	this := ConnectionChangeOperation{}
 	this.Op = op
 	this.Path = path
@@ -101,9 +101,10 @@ func (o *ConnectionChangeOperation) SetPath(v string) {
 }
 
 // GetValue returns the Value field value
-func (o *ConnectionChangeOperation) GetValue() map[string]interface{} {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *ConnectionChangeOperation) GetValue() interface{} {
 	if o == nil {
-		var ret map[string]interface{}
+		var ret interface{}
 		return ret
 	}
 
@@ -112,15 +113,16 @@ func (o *ConnectionChangeOperation) GetValue() map[string]interface{} {
 
 // GetValueOk returns a tuple with the Value field value
 // and a boolean to check if the value has been set.
-func (o *ConnectionChangeOperation) GetValueOk() (map[string]interface{}, bool) {
-	if o == nil {
-		return map[string]interface{}{}, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ConnectionChangeOperation) GetValueOk() (*interface{}, bool) {
+	if o == nil || IsNil(o.Value) {
+		return nil, false
 	}
-	return o.Value, true
+	return &o.Value, true
 }
 
 // SetValue sets field value
-func (o *ConnectionChangeOperation) SetValue(v map[string]interface{}) {
+func (o *ConnectionChangeOperation) SetValue(v interface{}) {
 	o.Value = v
 }
 
@@ -136,7 +138,9 @@ func (o ConnectionChangeOperation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["op"] = o.Op
 	toSerialize["path"] = o.Path
-	toSerialize["value"] = o.Value
+	if o.Value != nil {
+		toSerialize["value"] = o.Value
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value

--- a/services/fabricv4/model_network_change_operation.go
+++ b/services/fabricv4/model_network_change_operation.go
@@ -25,7 +25,7 @@ type NetworkChangeOperation struct {
 	// path inside document leading to updated parameter
 	Path string `json:"path"`
 	// new value for updated parameter
-	Value                map[string]interface{} `json:"value"`
+	Value                interface{} `json:"value"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -35,7 +35,7 @@ type _NetworkChangeOperation NetworkChangeOperation
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewNetworkChangeOperation(op PrecisionTimeChangeOperationOp, path string, value map[string]interface{}) *NetworkChangeOperation {
+func NewNetworkChangeOperation(op PrecisionTimeChangeOperationOp, path string, value interface{}) *NetworkChangeOperation {
 	this := NetworkChangeOperation{}
 	this.Op = op
 	this.Path = path
@@ -100,9 +100,10 @@ func (o *NetworkChangeOperation) SetPath(v string) {
 }
 
 // GetValue returns the Value field value
-func (o *NetworkChangeOperation) GetValue() map[string]interface{} {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *NetworkChangeOperation) GetValue() interface{} {
 	if o == nil {
-		var ret map[string]interface{}
+		var ret interface{}
 		return ret
 	}
 
@@ -111,15 +112,16 @@ func (o *NetworkChangeOperation) GetValue() map[string]interface{} {
 
 // GetValueOk returns a tuple with the Value field value
 // and a boolean to check if the value has been set.
-func (o *NetworkChangeOperation) GetValueOk() (map[string]interface{}, bool) {
-	if o == nil {
-		return map[string]interface{}{}, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *NetworkChangeOperation) GetValueOk() (*interface{}, bool) {
+	if o == nil || IsNil(o.Value) {
+		return nil, false
 	}
-	return o.Value, true
+	return &o.Value, true
 }
 
 // SetValue sets field value
-func (o *NetworkChangeOperation) SetValue(v map[string]interface{}) {
+func (o *NetworkChangeOperation) SetValue(v interface{}) {
 	o.Value = v
 }
 
@@ -135,7 +137,9 @@ func (o NetworkChangeOperation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["op"] = o.Op
 	toSerialize["path"] = o.Path
-	toSerialize["value"] = o.Value
+	if o.Value != nil {
+		toSerialize["value"] = o.Value
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value

--- a/services/fabricv4/model_precision_time_change_operation.go
+++ b/services/fabricv4/model_precision_time_change_operation.go
@@ -24,7 +24,7 @@ type PrecisionTimeChangeOperation struct {
 	Op   PrecisionTimeChangeOperationOp   `json:"op"`
 	Path PrecisionTimeChangeOperationPath `json:"path"`
 	// new value for updated parameter
-	Value                map[string]interface{} `json:"value"`
+	Value                interface{} `json:"value"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -34,7 +34,7 @@ type _PrecisionTimeChangeOperation PrecisionTimeChangeOperation
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewPrecisionTimeChangeOperation(op PrecisionTimeChangeOperationOp, path PrecisionTimeChangeOperationPath, value map[string]interface{}) *PrecisionTimeChangeOperation {
+func NewPrecisionTimeChangeOperation(op PrecisionTimeChangeOperationOp, path PrecisionTimeChangeOperationPath, value interface{}) *PrecisionTimeChangeOperation {
 	this := PrecisionTimeChangeOperation{}
 	this.Op = op
 	this.Path = path
@@ -99,9 +99,10 @@ func (o *PrecisionTimeChangeOperation) SetPath(v PrecisionTimeChangeOperationPat
 }
 
 // GetValue returns the Value field value
-func (o *PrecisionTimeChangeOperation) GetValue() map[string]interface{} {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *PrecisionTimeChangeOperation) GetValue() interface{} {
 	if o == nil {
-		var ret map[string]interface{}
+		var ret interface{}
 		return ret
 	}
 
@@ -110,15 +111,16 @@ func (o *PrecisionTimeChangeOperation) GetValue() map[string]interface{} {
 
 // GetValueOk returns a tuple with the Value field value
 // and a boolean to check if the value has been set.
-func (o *PrecisionTimeChangeOperation) GetValueOk() (map[string]interface{}, bool) {
-	if o == nil {
-		return map[string]interface{}{}, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *PrecisionTimeChangeOperation) GetValueOk() (*interface{}, bool) {
+	if o == nil || IsNil(o.Value) {
+		return nil, false
 	}
-	return o.Value, true
+	return &o.Value, true
 }
 
 // SetValue sets field value
-func (o *PrecisionTimeChangeOperation) SetValue(v map[string]interface{}) {
+func (o *PrecisionTimeChangeOperation) SetValue(v interface{}) {
 	o.Value = v
 }
 
@@ -134,7 +136,9 @@ func (o PrecisionTimeChangeOperation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["op"] = o.Op
 	toSerialize["path"] = o.Path
-	toSerialize["value"] = o.Value
+	if o.Value != nil {
+		toSerialize["value"] = o.Value
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value

--- a/services/fabricv4/model_service_token_change_operation.go
+++ b/services/fabricv4/model_service_token_change_operation.go
@@ -25,7 +25,7 @@ type ServiceTokenChangeOperation struct {
 	// path inside document leading to updated parameter
 	Path string `json:"path"`
 	// new value for updated parameter
-	Value                map[string]interface{} `json:"value"`
+	Value                interface{} `json:"value"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -35,7 +35,7 @@ type _ServiceTokenChangeOperation ServiceTokenChangeOperation
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewServiceTokenChangeOperation(op PrecisionTimeChangeOperationOp, path string, value map[string]interface{}) *ServiceTokenChangeOperation {
+func NewServiceTokenChangeOperation(op PrecisionTimeChangeOperationOp, path string, value interface{}) *ServiceTokenChangeOperation {
 	this := ServiceTokenChangeOperation{}
 	this.Op = op
 	this.Path = path
@@ -100,9 +100,10 @@ func (o *ServiceTokenChangeOperation) SetPath(v string) {
 }
 
 // GetValue returns the Value field value
-func (o *ServiceTokenChangeOperation) GetValue() map[string]interface{} {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *ServiceTokenChangeOperation) GetValue() interface{} {
 	if o == nil {
-		var ret map[string]interface{}
+		var ret interface{}
 		return ret
 	}
 
@@ -111,15 +112,16 @@ func (o *ServiceTokenChangeOperation) GetValue() map[string]interface{} {
 
 // GetValueOk returns a tuple with the Value field value
 // and a boolean to check if the value has been set.
-func (o *ServiceTokenChangeOperation) GetValueOk() (map[string]interface{}, bool) {
-	if o == nil {
-		return map[string]interface{}{}, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ServiceTokenChangeOperation) GetValueOk() (*interface{}, bool) {
+	if o == nil || IsNil(o.Value) {
+		return nil, false
 	}
-	return o.Value, true
+	return &o.Value, true
 }
 
 // SetValue sets field value
-func (o *ServiceTokenChangeOperation) SetValue(v map[string]interface{}) {
+func (o *ServiceTokenChangeOperation) SetValue(v interface{}) {
 	o.Value = v
 }
 
@@ -135,7 +137,9 @@ func (o ServiceTokenChangeOperation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["op"] = o.Op
 	toSerialize["path"] = o.Path
-	toSerialize["value"] = o.Value
+	if o.Value != nil {
+		toSerialize["value"] = o.Value
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value

--- a/spec/services/fabricv4/oas3.patched/swagger.yaml
+++ b/spec/services/fabricv4/oas3.patched/swagger.yaml
@@ -10304,7 +10304,6 @@ components:
             - /advanceConfiguration/ptp
             - /package
         value:
-          type: object
           description: new value for updated parameter
       description: Fabric Precision Timing change operation data
     precisionTimeServiceRequest:
@@ -10723,7 +10722,6 @@ components:
           description: path inside document leading to updated parameter
           example: /ipv6
         value:
-          type: object
           description: new value for updated parameter
       description: Connection change operation data
     Actions:
@@ -11174,7 +11172,6 @@ components:
           description: path inside document leading to updated parameter
           example: /expirationDateTime
         value:
-          type: object
           description: new value for updated parameter
       description: Service Token change operation data
     ServiceTokenActions:
@@ -11794,7 +11791,6 @@ components:
           type: string
           description: path inside document leading to updated parameter
         value:
-          type: object
           description: new value for updated parameter
       description: Fabric Cloud Router change operation data
     CloudRouterActionType:
@@ -11958,7 +11954,6 @@ components:
           description: path inside document leading to updated parameter
           example: /name
         value:
-          type: object
           description: new value for updated parameter
       description: Network change operation data
     NetworkSortCriteriaResponse:

--- a/spec/services/fabricv4/patches/20240305_use_anyType_for_change_operation_value.patch
+++ b/spec/services/fabricv4/patches/20240305_use_anyType_for_change_operation_value.patch
@@ -1,0 +1,51 @@
+diff --git a/spec/services/fabricv4/oas3.patched/swagger.yaml b/spec/services/fabricv4/oas3.patched/swagger.yaml
+index d552403..761c5fa 100644
+--- a/spec/services/fabricv4/oas3.patched/swagger.yaml
++++ b/spec/services/fabricv4/oas3.patched/swagger.yaml
+@@ -10304,7 +10304,6 @@ components:
+             - /advanceConfiguration/ptp
+             - /package
+         value:
+-          type: object
+           description: new value for updated parameter
+       description: Fabric Precision Timing change operation data
+     precisionTimeServiceRequest:
+@@ -10723,7 +10722,6 @@ components:
+           description: path inside document leading to updated parameter
+           example: /ipv6
+         value:
+-          type: object
+           description: new value for updated parameter
+       description: Connection change operation data
+     Actions:
+@@ -11174,7 +11172,6 @@ components:
+           description: path inside document leading to updated parameter
+           example: /expirationDateTime
+         value:
+-          type: object
+           description: new value for updated parameter
+       description: Service Token change operation data
+     ServiceTokenActions:
+@@ -11794,7 +11791,6 @@ components:
+           type: string
+           description: path inside document leading to updated parameter
+         value:
+-          type: object
+           description: new value for updated parameter
+       description: Fabric Cloud Router change operation data
+     CloudRouterActionType:
+@@ -11958,7 +11954,6 @@ components:
+           description: path inside document leading to updated parameter
+           example: /name
+         value:
+-          type: object
+           description: new value for updated parameter
+       description: Network change operation data
+     NetworkSortCriteriaResponse:
+@@ -23856,4 +23851,4 @@ components:
+     BearerAuth:
+       type: http
+       scheme: bearer
+-      bearerFormat: JWT
+\ No newline at end of file
++      bearerFormat: JWT


### PR DESCRIPTION
* Remove `type: object` from API Spec where intent is to have any type be acceptable from the API handler for that property
* Apply update via patching to Fabricv4 API Spec
* Go package `github.com/stretchr/testify` being upgraded from version `1.8.4` to `1.9.0`