### PR TITLE
docs: remove link to no-longer-used stability level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Equinix Go SDK
 
-[![Maintained](https://img.shields.io/badge/stability-maintained-green.svg)](https://github.com/equinix-labs/equinix-labs/blob/main/maintained-statement.md)
 [![Release](https://img.shields.io/github/v/release/equinix/equinix-sdk-go)](https://github.com/equinix/equinix-sdk-go/releases/latest)
 [![GoDoc](https://godoc.org/github.com/equinix/equinix-sdk-go?status.svg)](https://godoc.org/github.com/equinix/equinix-sdk-go)
 


### PR DESCRIPTION
In practice, stability levels do not provide additional meaning beyond what is already in the license file.  We are removing references to these stability levels to avoid setting unintended expectations for differing levels of maintenance.