### PR TITLE
fix: Patch change operation models

### DIFF
--- a/services/fabricv4/docs/RouteFilterRulesApi.md
+++ b/services/fabricv4/docs/RouteFilterRulesApi.md
@@ -556,7 +556,7 @@ import (
 func main() {
 	routeFilterId := "routeFilterId_example" // string | Route Filters Id
 	routeFilterRuleId := "routeFilterRuleId_example" // string | Route  Filter  Rules Id
-	routeFilterRulesPatchRequestItem := []openapiclient.RouteFilterRulesPatchRequestItem{*openapiclient.NewRouteFilterRulesPatchRequestItem("replace", "/prefixMatch", map[string]interface{}(123))} // []RouteFilterRulesPatchRequestItem | 
+	routeFilterRulesPatchRequestItem := []openapiclient.RouteFilterRulesPatchRequestItem{*openapiclient.NewRouteFilterRulesPatchRequestItem("replace", "/prefixMatch", interface{}(123))} // []RouteFilterRulesPatchRequestItem | 
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/services/fabricv4/docs/RouteFilterRulesPatchRequestItem.md
+++ b/services/fabricv4/docs/RouteFilterRulesPatchRequestItem.md
@@ -6,13 +6,13 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Op** | **string** | Handy shortcut for operation name | 
 **Path** | **string** | path to change | 
-**Value** | **map[string]interface{}** | new value for updated parameter | 
+**Value** | **interface{}** | new value for updated parameter | 
 
 ## Methods
 
 ### NewRouteFilterRulesPatchRequestItem
 
-`func NewRouteFilterRulesPatchRequestItem(op string, path string, value map[string]interface{}, ) *RouteFilterRulesPatchRequestItem`
+`func NewRouteFilterRulesPatchRequestItem(op string, path string, value interface{}, ) *RouteFilterRulesPatchRequestItem`
 
 NewRouteFilterRulesPatchRequestItem instantiates a new RouteFilterRulesPatchRequestItem object
 This constructor will assign default values to properties that have it defined,
@@ -69,24 +69,34 @@ SetPath sets Path field to given value.
 
 ### GetValue
 
-`func (o *RouteFilterRulesPatchRequestItem) GetValue() map[string]interface{}`
+`func (o *RouteFilterRulesPatchRequestItem) GetValue() interface{}`
 
 GetValue returns the Value field if non-nil, zero value otherwise.
 
 ### GetValueOk
 
-`func (o *RouteFilterRulesPatchRequestItem) GetValueOk() (*map[string]interface{}, bool)`
+`func (o *RouteFilterRulesPatchRequestItem) GetValueOk() (*interface{}, bool)`
 
 GetValueOk returns a tuple with the Value field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetValue
 
-`func (o *RouteFilterRulesPatchRequestItem) SetValue(v map[string]interface{})`
+`func (o *RouteFilterRulesPatchRequestItem) SetValue(v interface{})`
 
 SetValue sets Value field to given value.
 
 
+### SetValueNil
+
+`func (o *RouteFilterRulesPatchRequestItem) SetValueNil(b bool)`
+
+ SetValueNil sets the value for Value to be an explicit nil
+
+### UnsetValue
+`func (o *RouteFilterRulesPatchRequestItem) UnsetValue()`
+
+UnsetValue ensures that no value is present for Value, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/services/fabricv4/docs/RouteFiltersApi.md
+++ b/services/fabricv4/docs/RouteFiltersApi.md
@@ -755,7 +755,7 @@ import (
 
 func main() {
 	routeFilterId := "routeFilterId_example" // string | Route Filters Id
-	routeFiltersPatchRequestItem := []openapiclient.RouteFiltersPatchRequestItem{*openapiclient.NewRouteFiltersPatchRequestItem("replace", "/name", map[string]interface{}(123))} // []RouteFiltersPatchRequestItem | 
+	routeFiltersPatchRequestItem := []openapiclient.RouteFiltersPatchRequestItem{*openapiclient.NewRouteFiltersPatchRequestItem("replace", "/name", interface{}(123))} // []RouteFiltersPatchRequestItem | 
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/services/fabricv4/docs/RouteFiltersPatchRequestItem.md
+++ b/services/fabricv4/docs/RouteFiltersPatchRequestItem.md
@@ -6,13 +6,13 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Op** | **string** | Handy shortcut for operation name | 
 **Path** | **string** | path to change | 
-**Value** | **map[string]interface{}** | new value for updated parameter | 
+**Value** | **interface{}** | new value for updated parameter | 
 
 ## Methods
 
 ### NewRouteFiltersPatchRequestItem
 
-`func NewRouteFiltersPatchRequestItem(op string, path string, value map[string]interface{}, ) *RouteFiltersPatchRequestItem`
+`func NewRouteFiltersPatchRequestItem(op string, path string, value interface{}, ) *RouteFiltersPatchRequestItem`
 
 NewRouteFiltersPatchRequestItem instantiates a new RouteFiltersPatchRequestItem object
 This constructor will assign default values to properties that have it defined,
@@ -69,24 +69,34 @@ SetPath sets Path field to given value.
 
 ### GetValue
 
-`func (o *RouteFiltersPatchRequestItem) GetValue() map[string]interface{}`
+`func (o *RouteFiltersPatchRequestItem) GetValue() interface{}`
 
 GetValue returns the Value field if non-nil, zero value otherwise.
 
 ### GetValueOk
 
-`func (o *RouteFiltersPatchRequestItem) GetValueOk() (*map[string]interface{}, bool)`
+`func (o *RouteFiltersPatchRequestItem) GetValueOk() (*interface{}, bool)`
 
 GetValueOk returns a tuple with the Value field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetValue
 
-`func (o *RouteFiltersPatchRequestItem) SetValue(v map[string]interface{})`
+`func (o *RouteFiltersPatchRequestItem) SetValue(v interface{})`
 
 SetValue sets Value field to given value.
 
 
+### SetValueNil
+
+`func (o *RouteFiltersPatchRequestItem) SetValueNil(b bool)`
+
+ SetValueNil sets the value for Value to be an explicit nil
+
+### UnsetValue
+`func (o *RouteFiltersPatchRequestItem) UnsetValue()`
+
+UnsetValue ensures that no value is present for Value, not even an explicit nil
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/services/fabricv4/model_route_filter_rules_patch_request_item.go
+++ b/services/fabricv4/model_route_filter_rules_patch_request_item.go
@@ -23,7 +23,7 @@ type RouteFilterRulesPatchRequestItem struct {
 	// path to change
 	Path string `json:"path"`
 	// new value for updated parameter
-	Value                map[string]interface{} `json:"value"`
+	Value                interface{} `json:"value"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -33,7 +33,7 @@ type _RouteFilterRulesPatchRequestItem RouteFilterRulesPatchRequestItem
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRouteFilterRulesPatchRequestItem(op string, path string, value map[string]interface{}) *RouteFilterRulesPatchRequestItem {
+func NewRouteFilterRulesPatchRequestItem(op string, path string, value interface{}) *RouteFilterRulesPatchRequestItem {
 	this := RouteFilterRulesPatchRequestItem{}
 	this.Op = op
 	this.Path = path
@@ -98,9 +98,10 @@ func (o *RouteFilterRulesPatchRequestItem) SetPath(v string) {
 }
 
 // GetValue returns the Value field value
-func (o *RouteFilterRulesPatchRequestItem) GetValue() map[string]interface{} {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *RouteFilterRulesPatchRequestItem) GetValue() interface{} {
 	if o == nil {
-		var ret map[string]interface{}
+		var ret interface{}
 		return ret
 	}
 
@@ -109,15 +110,16 @@ func (o *RouteFilterRulesPatchRequestItem) GetValue() map[string]interface{} {
 
 // GetValueOk returns a tuple with the Value field value
 // and a boolean to check if the value has been set.
-func (o *RouteFilterRulesPatchRequestItem) GetValueOk() (map[string]interface{}, bool) {
-	if o == nil {
-		return map[string]interface{}{}, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RouteFilterRulesPatchRequestItem) GetValueOk() (*interface{}, bool) {
+	if o == nil || IsNil(o.Value) {
+		return nil, false
 	}
-	return o.Value, true
+	return &o.Value, true
 }
 
 // SetValue sets field value
-func (o *RouteFilterRulesPatchRequestItem) SetValue(v map[string]interface{}) {
+func (o *RouteFilterRulesPatchRequestItem) SetValue(v interface{}) {
 	o.Value = v
 }
 
@@ -133,7 +135,9 @@ func (o RouteFilterRulesPatchRequestItem) ToMap() (map[string]interface{}, error
 	toSerialize := map[string]interface{}{}
 	toSerialize["op"] = o.Op
 	toSerialize["path"] = o.Path
-	toSerialize["value"] = o.Value
+	if o.Value != nil {
+		toSerialize["value"] = o.Value
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value

--- a/services/fabricv4/model_route_filters_patch_request_item.go
+++ b/services/fabricv4/model_route_filters_patch_request_item.go
@@ -23,7 +23,7 @@ type RouteFiltersPatchRequestItem struct {
 	// path to change
 	Path string `json:"path"`
 	// new value for updated parameter
-	Value                map[string]interface{} `json:"value"`
+	Value                interface{} `json:"value"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -33,7 +33,7 @@ type _RouteFiltersPatchRequestItem RouteFiltersPatchRequestItem
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRouteFiltersPatchRequestItem(op string, path string, value map[string]interface{}) *RouteFiltersPatchRequestItem {
+func NewRouteFiltersPatchRequestItem(op string, path string, value interface{}) *RouteFiltersPatchRequestItem {
 	this := RouteFiltersPatchRequestItem{}
 	this.Op = op
 	this.Path = path
@@ -98,9 +98,10 @@ func (o *RouteFiltersPatchRequestItem) SetPath(v string) {
 }
 
 // GetValue returns the Value field value
-func (o *RouteFiltersPatchRequestItem) GetValue() map[string]interface{} {
+// If the value is explicit nil, the zero value for interface{} will be returned
+func (o *RouteFiltersPatchRequestItem) GetValue() interface{} {
 	if o == nil {
-		var ret map[string]interface{}
+		var ret interface{}
 		return ret
 	}
 
@@ -109,15 +110,16 @@ func (o *RouteFiltersPatchRequestItem) GetValue() map[string]interface{} {
 
 // GetValueOk returns a tuple with the Value field value
 // and a boolean to check if the value has been set.
-func (o *RouteFiltersPatchRequestItem) GetValueOk() (map[string]interface{}, bool) {
-	if o == nil {
-		return map[string]interface{}{}, false
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RouteFiltersPatchRequestItem) GetValueOk() (*interface{}, bool) {
+	if o == nil || IsNil(o.Value) {
+		return nil, false
 	}
-	return o.Value, true
+	return &o.Value, true
 }
 
 // SetValue sets field value
-func (o *RouteFiltersPatchRequestItem) SetValue(v map[string]interface{}) {
+func (o *RouteFiltersPatchRequestItem) SetValue(v interface{}) {
 	o.Value = v
 }
 
@@ -133,7 +135,9 @@ func (o RouteFiltersPatchRequestItem) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["op"] = o.Op
 	toSerialize["path"] = o.Path
-	toSerialize["value"] = o.Value
+	if o.Value != nil {
+		toSerialize["value"] = o.Value
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value

--- a/spec/services/fabricv4/oas3.patched/swagger.yaml
+++ b/spec/services/fabricv4/oas3.patched/swagger.yaml
@@ -12346,7 +12346,6 @@ components:
           description: path to change
           example: /name
         value:
-          type: object
           description: new value for updated parameter
       description: Route Filter change operation data
     RouteFiltersChangeOperation:
@@ -12439,7 +12438,6 @@ components:
           description: path to change
           example: /prefixMatch
         value:
-          type: object
           description: new value for updated parameter
       description: Route Filter Rule change operation data
     RouteFilterRulesChangeOperation:

--- a/spec/services/fabricv4/patches/20240909_patch_route_filter_change_models.patch
+++ b/spec/services/fabricv4/patches/20240909_patch_route_filter_change_models.patch
@@ -1,0 +1,20 @@
+diff --git a/spec/services/fabricv4/oas3.patched/swagger.yaml b/spec/services/fabricv4/oas3.patched/swagger.yaml
+index ac39f1e..3276e4a 100644
+--- a/spec/services/fabricv4/oas3.patched/swagger.yaml
++++ b/spec/services/fabricv4/oas3.patched/swagger.yaml
+@@ -12346,7 +12346,6 @@ components:
+           description: path to change
+           example: /name
+         value:
+-          type: object
+           description: new value for updated parameter
+       description: Route Filter change operation data
+     RouteFiltersChangeOperation:
+@@ -12439,7 +12438,6 @@ components:
+           description: path to change
+           example: /prefixMatch
+         value:
+-          type: object
+           description: new value for updated parameter
+       description: Route Filter Rule change operation data
+     RouteFilterRulesChangeOperation:


### PR DESCRIPTION
Patching necessary to move from `type: object` to OAS `any` type to allow for objects, or primitive types in the value portion of the change items.

* Patch Route Filters Change model
* Patch Route Filter Rules Change model