### PR TITLE
chore: override workdir for openapi-generator container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OPENAPI_IMAGE_TAG=v7.10.0
 OPENAPI_IMAGE=openapitools/openapi-generator-cli:${OPENAPI_IMAGE_TAG}
 CRI=docker # nerdctl
 CRI_COMMAND_BASE=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} $(DOCKER_EXTRA_ARGS)
-OPENAPI_GENERATOR=${CRI_COMMAND_BASE} -v $(CURDIR):/local -w /local ${OPENAPI_IMAGE}
+OPENAPI_GENERATOR=${CRI_COMMAND_BASE} -v $(CURDIR):/workdir -w /workdir ${OPENAPI_IMAGE}
 SPEC_FETCHER=${CRI_COMMAND_BASE} -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
 MIN_GO_VERSION=1.19
 GO_CMD=${CRI_COMMAND_BASE} -v $(CURDIR):/workdir -w /workdir -e GOCACHE=/tmp/.cache golang:${MIN_GO_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ OPENAPI_IMAGE_TAG=v7.10.0
 OPENAPI_IMAGE=openapitools/openapi-generator-cli:${OPENAPI_IMAGE_TAG}
 CRI=docker # nerdctl
 CRI_COMMAND_BASE=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} $(DOCKER_EXTRA_ARGS)
-OPENAPI_GENERATOR=${CRI_COMMAND_BASE} -v $(CURDIR):/local ${OPENAPI_IMAGE}
+OPENAPI_GENERATOR=${CRI_COMMAND_BASE} -v $(CURDIR):/local -w /local ${OPENAPI_IMAGE}
 SPEC_FETCHER=${CRI_COMMAND_BASE} -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
 MIN_GO_VERSION=1.19
 GO_CMD=${CRI_COMMAND_BASE} -v $(CURDIR):/workdir -w /workdir -e GOCACHE=/tmp/.cache golang:${MIN_GO_VERSION}

--- a/Makefile.eiav2
+++ b/Makefile.eiav2
@@ -48,15 +48,15 @@ codegen:
 		-p packageVersion=${PACKAGE_VERSION} \
 		--git-user-id ${GIT_ORG} \
 		--git-repo-id ${GIT_REPO}/services \
-		-c /local/config/openapi-generator.json \
-		-t /local/${TEMPLATE_DIR} \
-		-o /local/${CODE_DIR} \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
+		-c config/openapi-generator.json \
+		-t ${TEMPLATE_DIR} \
+		-o ${CODE_DIR} \
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
 
 validate:
 	${OPENAPI_GENERATOR} validate \
 		--recommend \
-		-i /local/${SPEC_PATCHED_DIR}
+		-i ${SPEC_PATCHED_DIR}
 
 remove-unused:
 	rm -rf ${CODE_DIR}/api \

--- a/Makefile.fabricv4
+++ b/Makefile.fabricv4
@@ -47,15 +47,15 @@ codegen:
 		-p packageVersion=${PACKAGE_VERSION} \
 		--git-user-id ${GIT_ORG} \
 		--git-repo-id ${GIT_REPO}/services \
-		-c /local/config/openapi-generator.json \
-		-t /local/${TEMPLATE_DIR} \
-		-o /local/${CODE_DIR} \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
+		-c config/openapi-generator.json \
+		-t ${TEMPLATE_DIR} \
+		-o ${CODE_DIR} \
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
 
 validate:
 	${OPENAPI_GENERATOR} validate \
 		--recommend \
-		-i /local/${SPEC_PATCHED_DIR}
+		-i ${SPEC_PATCHED_DIR}
 
 remove-unused:
 	rm -rf ${CODE_DIR}/api \

--- a/Makefile.metalv1
+++ b/Makefile.metalv1
@@ -46,7 +46,7 @@ codegen:
 	# to use v7.4.0 of openapi-generator to merge the
 	# spec in order to avoid introducing duplicate models
 	${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} \
-	    -v $(CURDIR):/local -w /local \
+	    -v $(CURDIR):/workdir -w /workdir \
 		openapitools/openapi-generator-cli:v7.4.0 \
 		generate \
 		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE} \

--- a/Makefile.metalv1
+++ b/Makefile.metalv1
@@ -46,13 +46,13 @@ codegen:
 	# to use v7.4.0 of openapi-generator to merge the
 	# spec in order to avoid introducing duplicate models
 	${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} \
-	    -v $(CURDIR):/local \
+	    -v $(CURDIR):/local -w /local \
 		openapitools/openapi-generator-cli:v7.4.0 \
 		generate \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE} \
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE} \
 		-g openapi-yaml \
 		-p skipOperationExample=true -p outputFile=${SPEC_ROOT_FILE} \
-		-o /local/${SPEC_BASE_DIR}/${PACKAGE_NAME}/temp_merged_spec
+		-o ${SPEC_BASE_DIR}/${PACKAGE_NAME}/temp_merged_spec
 
 	${OPENAPI_GENERATOR} generate -g go \
 		--package-name ${PACKAGE_NAME} \
@@ -60,18 +60,18 @@ codegen:
 		-p packageVersion=${PACKAGE_VERSION} \
 		--git-user-id ${GIT_ORG} \
 		--git-repo-id ${GIT_REPO}/services \
-		-c /local/config/openapi-generator.json \
-		-t /local/${TEMPLATE_DIR} \
-		-o /local/${CODE_DIR} \
-		-i /local/${SPEC_BASE_DIR}/${PACKAGE_NAME}/temp_merged_spec/${SPEC_ROOT_FILE}
-        # -i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE} # switch back to this when the temporary merged spec is removed
+		-c config/openapi-generator.json \
+		-t ${TEMPLATE_DIR} \
+		-o ${CODE_DIR} \
+		-i ${SPEC_BASE_DIR}/${PACKAGE_NAME}/temp_merged_spec/${SPEC_ROOT_FILE}
+        # -i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE} # switch back to this when the temporary merged spec is removed
 
 	rm -rf ${SPEC_BASE_DIR}/${PACKAGE_NAME}/temp_merged_spec
 		
 validate:
 	${OPENAPI_GENERATOR} validate \
 		--recommend \
-		-i /local/${SPEC_PATCHED_DIR}
+		-i ${SPEC_PATCHED_DIR}
 
 remove-unused:
 	rm -rf ${CODE_DIR}/api \

--- a/templates/Makefile.sdk
+++ b/templates/Makefile.sdk
@@ -46,15 +46,15 @@ codegen:
 		-p packageVersion=${PACKAGE_VERSION} \
 		--git-user-id ${GIT_ORG} \
 		--git-repo-id ${GIT_REPO}/services \
-		-c /local/config/openapi-generator.json \
-		-t /local/${TEMPLATE_DIR} \
-		-o /local/${CODE_DIR} \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
+		-c config/openapi-generator.json \
+		-t ${TEMPLATE_DIR} \
+		-o ${CODE_DIR} \
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
 
 validate:
 	${OPENAPI_GENERATOR} validate \
 		--recommend \
-		-i /local/${SPEC_PATCHED_DIR}
+		-i ${SPEC_PATCHED_DIR}
 
 remove-unused:
 	rm -rf ${CODE_DIR}/api \


### PR DESCRIPTION
This sets the volume mount location & working directory for the openapi-generator container to `/workdir` so that:

1. we don't have to specify the absolute path to spec/service/etc. files for commands that run in that container
2. we use the same path for mounting the local directory into all containers

This saves us from having to remember which commands are running in a container and which containers require absolute paths instead of relative paths for repository files.