### PR TITLE
fix: Adding patch for removing CustomField description from required in POST Service Profile Search

### DIFF
--- a/services/fabricv4/docs/CustomField.md
+++ b/services/fabricv4/docs/CustomField.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Label** | **string** |  | 
-**Description** | **string** |  | 
+**Description** | Pointer to **string** |  | [optional] 
 **Required** | Pointer to **bool** |  | [optional] 
 **DataType** | [**CustomFieldDataType**](CustomFieldDataType.md) |  | 
 **Options** | Pointer to **[]string** |  | [optional] 
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 
 ### NewCustomField
 
-`func NewCustomField(label string, description string, dataType CustomFieldDataType, ) *CustomField`
+`func NewCustomField(label string, dataType CustomFieldDataType, ) *CustomField`
 
 NewCustomField instantiates a new CustomField object
 This constructor will assign default values to properties that have it defined,
@@ -69,6 +69,11 @@ and a boolean to check if the value has been set.
 
 SetDescription sets Description field to given value.
 
+### HasDescription
+
+`func (o *CustomField) HasDescription() bool`
+
+HasDescription returns a boolean if a field has been set.
 
 ### GetRequired
 

--- a/services/fabricv4/model_custom_field.go
+++ b/services/fabricv4/model_custom_field.go
@@ -18,7 +18,7 @@ var _ MappedNullable = &CustomField{}
 // CustomField Define Custom Attributes
 type CustomField struct {
 	Label       string              `json:"label"`
-	Description string              `json:"description"`
+	Description *string             `json:"description,omitempty"`
 	Required    *bool               `json:"required,omitempty"`
 	DataType    CustomFieldDataType `json:"dataType"`
 	Options     []string            `json:"options,omitempty"`
@@ -33,10 +33,9 @@ type _CustomField CustomField
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCustomField(label string, description string, dataType CustomFieldDataType) *CustomField {
+func NewCustomField(label string, dataType CustomFieldDataType) *CustomField {
 	this := CustomField{}
 	this.Label = label
-	this.Description = description
 	this.DataType = dataType
 	return &this
 }
@@ -73,28 +72,36 @@ func (o *CustomField) SetLabel(v string) {
 	o.Label = v
 }
 
-// GetDescription returns the Description field value
+// GetDescription returns the Description field value if set, zero value otherwise.
 func (o *CustomField) GetDescription() string {
-	if o == nil {
+	if o == nil || IsNil(o.Description) {
 		var ret string
 		return ret
 	}
-
-	return o.Description
+	return *o.Description
 }
 
-// GetDescriptionOk returns a tuple with the Description field value
+// GetDescriptionOk returns a tuple with the Description field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CustomField) GetDescriptionOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Description) {
 		return nil, false
 	}
-	return &o.Description, true
+	return o.Description, true
 }
 
-// SetDescription sets field value
+// HasDescription returns a boolean if a field has been set.
+func (o *CustomField) HasDescription() bool {
+	if o != nil && !IsNil(o.Description) {
+		return true
+	}
+
+	return false
+}
+
+// SetDescription gets a reference to the given string and assigns it to the Description field.
 func (o *CustomField) SetDescription(v string) {
-	o.Description = v
+	o.Description = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -228,7 +235,9 @@ func (o CustomField) MarshalJSON() ([]byte, error) {
 func (o CustomField) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["label"] = o.Label
-	toSerialize["description"] = o.Description
+	if !IsNil(o.Description) {
+		toSerialize["description"] = o.Description
+	}
 	if !IsNil(o.Required) {
 		toSerialize["required"] = o.Required
 	}
@@ -253,7 +262,6 @@ func (o *CustomField) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"label",
-		"description",
 		"dataType",
 	}
 

--- a/spec/services/fabricv4/oas3.patched/swagger.yaml
+++ b/spec/services/fabricv4/oas3.patched/swagger.yaml
@@ -12648,7 +12648,6 @@ components:
     CustomField:
       required:
         - dataType
-        - description
         - isRequired
         - label
       properties:

--- a/spec/services/fabricv4/patches/20250228_remove_description_from_required_in_custom_field_service_profile_patch_value.patch
+++ b/spec/services/fabricv4/patches/20250228_remove_description_from_required_in_custom_field_service_profile_patch_value.patch
@@ -1,0 +1,12 @@
+diff --git a/spec/services/fabricv4/oas3.patched/swagger.yaml b/spec/services/fabricv4/oas3.patched/swagger.yaml
+index 734e5b81..1d793154 100644
+--- a/spec/services/fabricv4/oas3.patched/swagger.yaml
++++ b/spec/services/fabricv4/oas3.patched/swagger.yaml
+@@ -12648,7 +12648,6 @@ components:
+     CustomField:
+       required:
+         - dataType
+-        - description
+         - isRequired
+         - label
+       properties:


### PR DESCRIPTION
Removed the `CustomField` `description` from required list in `POST` Service Profile Search
```
CustomField:
    required: 
        - description 
```
