### PR TITLE
fix: Cloud router coupling patch

### DIFF
--- a/services/fabricv4/docs/CloudRouter.md
+++ b/services/fabricv4/docs/CloudRouter.md
@@ -12,10 +12,10 @@ Name | Type | Description | Notes
 **MarketplaceSubscription** | Pointer to [**MarketplaceSubscription**](MarketplaceSubscription.md) |  | [optional] 
 **ChangeLog** | Pointer to [**Changelog**](Changelog.md) |  | [optional] 
 **Change** | Pointer to [**CloudRouterChange**](CloudRouterChange.md) |  | [optional] 
-**Type** | [**CloudRouterPostRequestType**](CloudRouterPostRequestType.md) |  | 
-**Name** | **string** | Customer-provided Cloud Router name | 
-**Location** | [**SimplifiedLocationWithoutIBX**](SimplifiedLocationWithoutIBX.md) |  | 
-**Package** | [**CloudRouterPostRequestPackage**](CloudRouterPostRequestPackage.md) |  | 
+**Type** | Pointer to [**CloudRouterPostRequestType**](CloudRouterPostRequestType.md) |  | [optional] 
+**Name** | Pointer to **string** | Customer-provided Cloud Router name | [optional] 
+**Location** | Pointer to [**SimplifiedLocationWithoutIBX**](SimplifiedLocationWithoutIBX.md) |  | [optional] 
+**Package** | Pointer to [**CloudRouterPostRequestPackage**](CloudRouterPostRequestPackage.md) |  | [optional] 
 **Order** | Pointer to [**Order**](Order.md) |  | [optional] 
 **Project** | Pointer to [**Project**](Project.md) |  | [optional] 
 **Account** | Pointer to [**SimplifiedAccount**](SimplifiedAccount.md) |  | [optional] 
@@ -25,7 +25,7 @@ Name | Type | Description | Notes
 
 ### NewCloudRouter
 
-`func NewCloudRouter(type_ CloudRouterPostRequestType, name string, location SimplifiedLocationWithoutIBX, package_ CloudRouterPostRequestPackage, ) *CloudRouter`
+`func NewCloudRouter() *CloudRouter`
 
 NewCloudRouter instantiates a new CloudRouter object
 This constructor will assign default values to properties that have it defined,
@@ -259,6 +259,11 @@ and a boolean to check if the value has been set.
 
 SetType sets Type field to given value.
 
+### HasType
+
+`func (o *CloudRouter) HasType() bool`
+
+HasType returns a boolean if a field has been set.
 
 ### GetName
 
@@ -279,6 +284,11 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *CloudRouter) HasName() bool`
+
+HasName returns a boolean if a field has been set.
 
 ### GetLocation
 
@@ -299,6 +309,11 @@ and a boolean to check if the value has been set.
 
 SetLocation sets Location field to given value.
 
+### HasLocation
+
+`func (o *CloudRouter) HasLocation() bool`
+
+HasLocation returns a boolean if a field has been set.
 
 ### GetPackage
 
@@ -319,6 +334,11 @@ and a boolean to check if the value has been set.
 
 SetPackage sets Package field to given value.
 
+### HasPackage
+
+`func (o *CloudRouter) HasPackage() bool`
+
+HasPackage returns a boolean if a field has been set.
 
 ### GetOrder
 

--- a/services/fabricv4/docs/CloudRouterPostRequest.md
+++ b/services/fabricv4/docs/CloudRouterPostRequest.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | [**CloudRouterPostRequestType**](CloudRouterPostRequestType.md) |  | 
-**Name** | **string** | Customer-provided Cloud Router name | 
-**Location** | [**SimplifiedLocationWithoutIBX**](SimplifiedLocationWithoutIBX.md) |  | 
-**Package** | [**CloudRouterPostRequestPackage**](CloudRouterPostRequestPackage.md) |  | 
+**Type** | Pointer to [**CloudRouterPostRequestType**](CloudRouterPostRequestType.md) |  | [optional] 
+**Name** | Pointer to **string** | Customer-provided Cloud Router name | [optional] 
+**Location** | Pointer to [**SimplifiedLocationWithoutIBX**](SimplifiedLocationWithoutIBX.md) |  | [optional] 
+**Package** | Pointer to [**CloudRouterPostRequestPackage**](CloudRouterPostRequestPackage.md) |  | [optional] 
 **Order** | Pointer to [**Order**](Order.md) |  | [optional] 
 **Project** | Pointer to [**Project**](Project.md) |  | [optional] 
 **Account** | Pointer to [**SimplifiedAccount**](SimplifiedAccount.md) |  | [optional] 
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 
 ### NewCloudRouterPostRequest
 
-`func NewCloudRouterPostRequest(type_ CloudRouterPostRequestType, name string, location SimplifiedLocationWithoutIBX, package_ CloudRouterPostRequestPackage, ) *CloudRouterPostRequest`
+`func NewCloudRouterPostRequest() *CloudRouterPostRequest`
 
 NewCloudRouterPostRequest instantiates a new CloudRouterPostRequest object
 This constructor will assign default values to properties that have it defined,
@@ -52,6 +52,11 @@ and a boolean to check if the value has been set.
 
 SetType sets Type field to given value.
 
+### HasType
+
+`func (o *CloudRouterPostRequest) HasType() bool`
+
+HasType returns a boolean if a field has been set.
 
 ### GetName
 
@@ -72,6 +77,11 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+### HasName
+
+`func (o *CloudRouterPostRequest) HasName() bool`
+
+HasName returns a boolean if a field has been set.
 
 ### GetLocation
 
@@ -92,6 +102,11 @@ and a boolean to check if the value has been set.
 
 SetLocation sets Location field to given value.
 
+### HasLocation
+
+`func (o *CloudRouterPostRequest) HasLocation() bool`
+
+HasLocation returns a boolean if a field has been set.
 
 ### GetPackage
 
@@ -112,6 +127,11 @@ and a boolean to check if the value has been set.
 
 SetPackage sets Package field to given value.
 
+### HasPackage
+
+`func (o *CloudRouterPostRequest) HasPackage() bool`
+
+HasPackage returns a boolean if a field has been set.
 
 ### GetOrder
 

--- a/services/fabricv4/docs/CloudRoutersApi.md
+++ b/services/fabricv4/docs/CloudRoutersApi.md
@@ -47,7 +47,7 @@ import (
 )
 
 func main() {
-	cloudRouterPostRequest := *openapiclient.NewCloudRouterPostRequest(openapiclient.CloudRouterPostRequest_type("XF_ROUTER"), "test-fg-1", *openapiclient.NewSimplifiedLocationWithoutIBX("AM"), *openapiclient.NewCloudRouterPostRequestPackage(openapiclient.CloudRouterPostRequestPackage_code("LAB"))) // CloudRouterPostRequest | 
+	cloudRouterPostRequest := *openapiclient.NewCloudRouterPostRequest() // CloudRouterPostRequest | 
 	dryRun := true // bool | option to verify that API calls will succeed (optional) (default to false)
 
 	configuration := openapiclient.NewConfiguration()

--- a/services/fabricv4/model_cloud_router.go
+++ b/services/fabricv4/model_cloud_router.go
@@ -9,7 +9,6 @@ package fabricv4
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // checks if the CloudRouter type satisfies the MappedNullable interface at compile time
@@ -25,18 +24,18 @@ type CloudRouter struct {
 	// Equinix ASN
 	EquinixAsn *int64 `json:"equinixAsn,omitempty"`
 	// Number of connections associated with this Access point
-	ConnectionsCount        *int32                     `json:"connectionsCount,omitempty"`
-	MarketplaceSubscription *MarketplaceSubscription   `json:"marketplaceSubscription,omitempty"`
-	ChangeLog               *Changelog                 `json:"changeLog,omitempty"`
-	Change                  *CloudRouterChange         `json:"change,omitempty"`
-	Type                    CloudRouterPostRequestType `json:"type"`
+	ConnectionsCount        *int32                      `json:"connectionsCount,omitempty"`
+	MarketplaceSubscription *MarketplaceSubscription    `json:"marketplaceSubscription,omitempty"`
+	ChangeLog               *Changelog                  `json:"changeLog,omitempty"`
+	Change                  *CloudRouterChange          `json:"change,omitempty"`
+	Type                    *CloudRouterPostRequestType `json:"type,omitempty"`
 	// Customer-provided Cloud Router name
-	Name     string                        `json:"name"`
-	Location SimplifiedLocationWithoutIBX  `json:"location"`
-	Package  CloudRouterPostRequestPackage `json:"package"`
-	Order    *Order                        `json:"order,omitempty"`
-	Project  *Project                      `json:"project,omitempty"`
-	Account  *SimplifiedAccount            `json:"account,omitempty"`
+	Name     *string                        `json:"name,omitempty"`
+	Location *SimplifiedLocationWithoutIBX  `json:"location,omitempty"`
+	Package  *CloudRouterPostRequestPackage `json:"package,omitempty"`
+	Order    *Order                         `json:"order,omitempty"`
+	Project  *Project                       `json:"project,omitempty"`
+	Account  *SimplifiedAccount             `json:"account,omitempty"`
 	// Preferences for notifications on connection configuration or status changes
 	Notifications        []SimplifiedNotification `json:"notifications,omitempty"`
 	AdditionalProperties map[string]interface{}
@@ -48,12 +47,8 @@ type _CloudRouter CloudRouter
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCloudRouter(type_ CloudRouterPostRequestType, name string, location SimplifiedLocationWithoutIBX, package_ CloudRouterPostRequestPackage) *CloudRouter {
+func NewCloudRouter() *CloudRouter {
 	this := CloudRouter{}
-	this.Type = type_
-	this.Name = name
-	this.Location = location
-	this.Package = package_
 	return &this
 }
 
@@ -321,100 +316,132 @@ func (o *CloudRouter) SetChange(v CloudRouterChange) {
 	o.Change = &v
 }
 
-// GetType returns the Type field value
+// GetType returns the Type field value if set, zero value otherwise.
 func (o *CloudRouter) GetType() CloudRouterPostRequestType {
-	if o == nil {
+	if o == nil || IsNil(o.Type) {
 		var ret CloudRouterPostRequestType
 		return ret
 	}
-
-	return o.Type
+	return *o.Type
 }
 
-// GetTypeOk returns a tuple with the Type field value
+// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CloudRouter) GetTypeOk() (*CloudRouterPostRequestType, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Type) {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
-// SetType sets field value
+// HasType returns a boolean if a field has been set.
+func (o *CloudRouter) HasType() bool {
+	if o != nil && !IsNil(o.Type) {
+		return true
+	}
+
+	return false
+}
+
+// SetType gets a reference to the given CloudRouterPostRequestType and assigns it to the Type field.
 func (o *CloudRouter) SetType(v CloudRouterPostRequestType) {
-	o.Type = v
+	o.Type = &v
 }
 
-// GetName returns the Name field value
+// GetName returns the Name field value if set, zero value otherwise.
 func (o *CloudRouter) GetName() string {
-	if o == nil {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
-
-	return o.Name
+	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CloudRouter) GetNameOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
-// SetName sets field value
+// HasName returns a boolean if a field has been set.
+func (o *CloudRouter) HasName() bool {
+	if o != nil && !IsNil(o.Name) {
+		return true
+	}
+
+	return false
+}
+
+// SetName gets a reference to the given string and assigns it to the Name field.
 func (o *CloudRouter) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
-// GetLocation returns the Location field value
+// GetLocation returns the Location field value if set, zero value otherwise.
 func (o *CloudRouter) GetLocation() SimplifiedLocationWithoutIBX {
-	if o == nil {
+	if o == nil || IsNil(o.Location) {
 		var ret SimplifiedLocationWithoutIBX
 		return ret
 	}
-
-	return o.Location
+	return *o.Location
 }
 
-// GetLocationOk returns a tuple with the Location field value
+// GetLocationOk returns a tuple with the Location field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CloudRouter) GetLocationOk() (*SimplifiedLocationWithoutIBX, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Location) {
 		return nil, false
 	}
-	return &o.Location, true
+	return o.Location, true
 }
 
-// SetLocation sets field value
+// HasLocation returns a boolean if a field has been set.
+func (o *CloudRouter) HasLocation() bool {
+	if o != nil && !IsNil(o.Location) {
+		return true
+	}
+
+	return false
+}
+
+// SetLocation gets a reference to the given SimplifiedLocationWithoutIBX and assigns it to the Location field.
 func (o *CloudRouter) SetLocation(v SimplifiedLocationWithoutIBX) {
-	o.Location = v
+	o.Location = &v
 }
 
-// GetPackage returns the Package field value
+// GetPackage returns the Package field value if set, zero value otherwise.
 func (o *CloudRouter) GetPackage() CloudRouterPostRequestPackage {
-	if o == nil {
+	if o == nil || IsNil(o.Package) {
 		var ret CloudRouterPostRequestPackage
 		return ret
 	}
-
-	return o.Package
+	return *o.Package
 }
 
-// GetPackageOk returns a tuple with the Package field value
+// GetPackageOk returns a tuple with the Package field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CloudRouter) GetPackageOk() (*CloudRouterPostRequestPackage, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Package) {
 		return nil, false
 	}
-	return &o.Package, true
+	return o.Package, true
 }
 
-// SetPackage sets field value
+// HasPackage returns a boolean if a field has been set.
+func (o *CloudRouter) HasPackage() bool {
+	if o != nil && !IsNil(o.Package) {
+		return true
+	}
+
+	return false
+}
+
+// SetPackage gets a reference to the given CloudRouterPostRequestPackage and assigns it to the Package field.
 func (o *CloudRouter) SetPackage(v CloudRouterPostRequestPackage) {
-	o.Package = v
+	o.Package = &v
 }
 
 // GetOrder returns the Order field value if set, zero value otherwise.
@@ -579,10 +606,18 @@ func (o CloudRouter) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Change) {
 		toSerialize["change"] = o.Change
 	}
-	toSerialize["type"] = o.Type
-	toSerialize["name"] = o.Name
-	toSerialize["location"] = o.Location
-	toSerialize["package"] = o.Package
+	if !IsNil(o.Type) {
+		toSerialize["type"] = o.Type
+	}
+	if !IsNil(o.Name) {
+		toSerialize["name"] = o.Name
+	}
+	if !IsNil(o.Location) {
+		toSerialize["location"] = o.Location
+	}
+	if !IsNil(o.Package) {
+		toSerialize["package"] = o.Package
+	}
 	if !IsNil(o.Order) {
 		toSerialize["order"] = o.Order
 	}
@@ -604,30 +639,6 @@ func (o CloudRouter) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *CloudRouter) UnmarshalJSON(data []byte) (err error) {
-	// This validates that all required properties are included in the JSON object
-	// by unmarshalling the object into a generic map with string keys and checking
-	// that every required field exists as a key in the generic map.
-	requiredProperties := []string{
-		"type",
-		"name",
-		"location",
-		"package",
-	}
-
-	allProperties := make(map[string]interface{})
-
-	err = json.Unmarshal(data, &allProperties)
-
-	if err != nil {
-		return err
-	}
-
-	for _, requiredProperty := range requiredProperties {
-		if _, exists := allProperties[requiredProperty]; !exists {
-			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-
 	varCloudRouter := _CloudRouter{}
 
 	err = json.Unmarshal(data, &varCloudRouter)

--- a/services/fabricv4/model_cloud_router_post_request.go
+++ b/services/fabricv4/model_cloud_router_post_request.go
@@ -9,7 +9,6 @@ package fabricv4
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // checks if the CloudRouterPostRequest type satisfies the MappedNullable interface at compile time
@@ -17,14 +16,14 @@ var _ MappedNullable = &CloudRouterPostRequest{}
 
 // CloudRouterPostRequest Create Cloud Router
 type CloudRouterPostRequest struct {
-	Type CloudRouterPostRequestType `json:"type"`
+	Type *CloudRouterPostRequestType `json:"type,omitempty"`
 	// Customer-provided Cloud Router name
-	Name     string                        `json:"name"`
-	Location SimplifiedLocationWithoutIBX  `json:"location"`
-	Package  CloudRouterPostRequestPackage `json:"package"`
-	Order    *Order                        `json:"order,omitempty"`
-	Project  *Project                      `json:"project,omitempty"`
-	Account  *SimplifiedAccount            `json:"account,omitempty"`
+	Name     *string                        `json:"name,omitempty"`
+	Location *SimplifiedLocationWithoutIBX  `json:"location,omitempty"`
+	Package  *CloudRouterPostRequestPackage `json:"package,omitempty"`
+	Order    *Order                         `json:"order,omitempty"`
+	Project  *Project                       `json:"project,omitempty"`
+	Account  *SimplifiedAccount             `json:"account,omitempty"`
 	// Preferences for notifications on connection configuration or status changes
 	Notifications           []SimplifiedNotification `json:"notifications,omitempty"`
 	MarketplaceSubscription *MarketplaceSubscription `json:"marketplaceSubscription,omitempty"`
@@ -37,12 +36,8 @@ type _CloudRouterPostRequest CloudRouterPostRequest
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCloudRouterPostRequest(type_ CloudRouterPostRequestType, name string, location SimplifiedLocationWithoutIBX, package_ CloudRouterPostRequestPackage) *CloudRouterPostRequest {
+func NewCloudRouterPostRequest() *CloudRouterPostRequest {
 	this := CloudRouterPostRequest{}
-	this.Type = type_
-	this.Name = name
-	this.Location = location
-	this.Package = package_
 	return &this
 }
 
@@ -54,100 +49,132 @@ func NewCloudRouterPostRequestWithDefaults() *CloudRouterPostRequest {
 	return &this
 }
 
-// GetType returns the Type field value
+// GetType returns the Type field value if set, zero value otherwise.
 func (o *CloudRouterPostRequest) GetType() CloudRouterPostRequestType {
-	if o == nil {
+	if o == nil || IsNil(o.Type) {
 		var ret CloudRouterPostRequestType
 		return ret
 	}
-
-	return o.Type
+	return *o.Type
 }
 
-// GetTypeOk returns a tuple with the Type field value
+// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CloudRouterPostRequest) GetTypeOk() (*CloudRouterPostRequestType, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Type) {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
-// SetType sets field value
+// HasType returns a boolean if a field has been set.
+func (o *CloudRouterPostRequest) HasType() bool {
+	if o != nil && !IsNil(o.Type) {
+		return true
+	}
+
+	return false
+}
+
+// SetType gets a reference to the given CloudRouterPostRequestType and assigns it to the Type field.
 func (o *CloudRouterPostRequest) SetType(v CloudRouterPostRequestType) {
-	o.Type = v
+	o.Type = &v
 }
 
-// GetName returns the Name field value
+// GetName returns the Name field value if set, zero value otherwise.
 func (o *CloudRouterPostRequest) GetName() string {
-	if o == nil {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
-
-	return o.Name
+	return *o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CloudRouterPostRequest) GetNameOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
-// SetName sets field value
+// HasName returns a boolean if a field has been set.
+func (o *CloudRouterPostRequest) HasName() bool {
+	if o != nil && !IsNil(o.Name) {
+		return true
+	}
+
+	return false
+}
+
+// SetName gets a reference to the given string and assigns it to the Name field.
 func (o *CloudRouterPostRequest) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
-// GetLocation returns the Location field value
+// GetLocation returns the Location field value if set, zero value otherwise.
 func (o *CloudRouterPostRequest) GetLocation() SimplifiedLocationWithoutIBX {
-	if o == nil {
+	if o == nil || IsNil(o.Location) {
 		var ret SimplifiedLocationWithoutIBX
 		return ret
 	}
-
-	return o.Location
+	return *o.Location
 }
 
-// GetLocationOk returns a tuple with the Location field value
+// GetLocationOk returns a tuple with the Location field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CloudRouterPostRequest) GetLocationOk() (*SimplifiedLocationWithoutIBX, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Location) {
 		return nil, false
 	}
-	return &o.Location, true
+	return o.Location, true
 }
 
-// SetLocation sets field value
+// HasLocation returns a boolean if a field has been set.
+func (o *CloudRouterPostRequest) HasLocation() bool {
+	if o != nil && !IsNil(o.Location) {
+		return true
+	}
+
+	return false
+}
+
+// SetLocation gets a reference to the given SimplifiedLocationWithoutIBX and assigns it to the Location field.
 func (o *CloudRouterPostRequest) SetLocation(v SimplifiedLocationWithoutIBX) {
-	o.Location = v
+	o.Location = &v
 }
 
-// GetPackage returns the Package field value
+// GetPackage returns the Package field value if set, zero value otherwise.
 func (o *CloudRouterPostRequest) GetPackage() CloudRouterPostRequestPackage {
-	if o == nil {
+	if o == nil || IsNil(o.Package) {
 		var ret CloudRouterPostRequestPackage
 		return ret
 	}
-
-	return o.Package
+	return *o.Package
 }
 
-// GetPackageOk returns a tuple with the Package field value
+// GetPackageOk returns a tuple with the Package field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CloudRouterPostRequest) GetPackageOk() (*CloudRouterPostRequestPackage, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Package) {
 		return nil, false
 	}
-	return &o.Package, true
+	return o.Package, true
 }
 
-// SetPackage sets field value
+// HasPackage returns a boolean if a field has been set.
+func (o *CloudRouterPostRequest) HasPackage() bool {
+	if o != nil && !IsNil(o.Package) {
+		return true
+	}
+
+	return false
+}
+
+// SetPackage gets a reference to the given CloudRouterPostRequestPackage and assigns it to the Package field.
 func (o *CloudRouterPostRequest) SetPackage(v CloudRouterPostRequestPackage) {
-	o.Package = v
+	o.Package = &v
 }
 
 // GetOrder returns the Order field value if set, zero value otherwise.
@@ -320,10 +347,18 @@ func (o CloudRouterPostRequest) MarshalJSON() ([]byte, error) {
 
 func (o CloudRouterPostRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["type"] = o.Type
-	toSerialize["name"] = o.Name
-	toSerialize["location"] = o.Location
-	toSerialize["package"] = o.Package
+	if !IsNil(o.Type) {
+		toSerialize["type"] = o.Type
+	}
+	if !IsNil(o.Name) {
+		toSerialize["name"] = o.Name
+	}
+	if !IsNil(o.Location) {
+		toSerialize["location"] = o.Location
+	}
+	if !IsNil(o.Package) {
+		toSerialize["package"] = o.Package
+	}
 	if !IsNil(o.Order) {
 		toSerialize["order"] = o.Order
 	}
@@ -348,30 +383,6 @@ func (o CloudRouterPostRequest) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *CloudRouterPostRequest) UnmarshalJSON(data []byte) (err error) {
-	// This validates that all required properties are included in the JSON object
-	// by unmarshalling the object into a generic map with string keys and checking
-	// that every required field exists as a key in the generic map.
-	requiredProperties := []string{
-		"type",
-		"name",
-		"location",
-		"package",
-	}
-
-	allProperties := make(map[string]interface{})
-
-	err = json.Unmarshal(data, &allProperties)
-
-	if err != nil {
-		return err
-	}
-
-	for _, requiredProperty := range requiredProperties {
-		if _, exists := allProperties[requiredProperty]; !exists {
-			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-
 	varCloudRouterPostRequest := _CloudRouterPostRequest{}
 
 	err = json.Unmarshal(data, &varCloudRouterPostRequest)

--- a/spec/services/fabricv4/oas3.patched/swagger.yaml
+++ b/spec/services/fabricv4/oas3.patched/swagger.yaml
@@ -15087,12 +15087,6 @@ components:
             $ref: "#/components/schemas/RouteAggregationRulesBase"
       description: Create Route Aggregation Rule POST request
     CloudRouterPostRequest:
-      required:
-        - location
-        - name
-        - notification
-        - package
-        - type
       type: object
       properties:
         type:

--- a/spec/services/fabricv4/patches/20250428_cloud_router_coupling_fix.patch
+++ b/spec/services/fabricv4/patches/20250428_cloud_router_coupling_fix.patch
@@ -1,8 +1,21 @@
 diff --git a/spec/services/fabricv4/oas3.patched/swagger.yaml b/spec/services/fabricv4/oas3.patched/swagger.yaml
-index 397ed50..4e317d1 100644
+index 8f2089e..616cc13 100644
 --- a/spec/services/fabricv4/oas3.patched/swagger.yaml
 +++ b/spec/services/fabricv4/oas3.patched/swagger.yaml
-@@ -14251,6 +14251,8 @@ components:
+@@ -15087,12 +15087,6 @@ components:
+             $ref: "#/components/schemas/RouteAggregationRulesBase"
+       description: Create Route Aggregation Rule POST request
+     CloudRouterPostRequest:
+-      required:
+-        - location
+-        - name
+-        - notification
+-        - package
+-        - type
+       type: object
+       properties:
+         type:
+@@ -15102,6 +15096,8 @@ components:
          name:
            type: string
            description: Customer-provided Cloud Router name
@@ -11,7 +24,7 @@ index 397ed50..4e317d1 100644
          location:
            $ref: "#/components/schemas/SimplifiedLocationWithoutIBX"
          package:
-@@ -14283,11 +14285,6 @@ components:
+@@ -15134,11 +15130,6 @@ components:
            description: Equinix-assigned access point identifier
            format: uuid
            example: c9b8e7a2-f3b1-4576-a4a9-1366a63df170


### PR DESCRIPTION
* Reverting previous patch and removing required fields from CloudRouterPostRequest model because of the coupling issue it has with AccessPoint and then Connections