### PR TITLE
chore(ci): bump golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OPENAPI_GENERATOR=${CRI_COMMAND_BASE} -v $(CURDIR):/workdir -w /workdir ${OPENAP
 SPEC_FETCHER=${CRI_COMMAND_BASE} -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
 MIN_GO_VERSION=1.19
 GO_CMD=${CRI_COMMAND_BASE} -v $(CURDIR):/workdir -w /workdir -e GOCACHE=/tmp/.cache golang:${MIN_GO_VERSION}
-GOLANGCI_LINT_VERSION=v2.0.2
+GOLANGCI_LINT_VERSION=v2.3.0
 GOLANGCI_LINT_IMAGE=golangci/golangci-lint:${GOLANGCI_LINT_VERSION}
 GOLANGCI_LINT=${CRI_COMMAND_BASE} -v $(CURDIR):/app -w /app -e GOLANGCI_LINT_CACHE=/tmp/.cache -e GOCACHE=/tmp/.cache ${GOLANGCI_LINT_IMAGE} golangci-lint
 


### PR DESCRIPTION
This bumps golangci-lint to the latest version to unblock #109. I tested locally to confirm that this does not introduce new lint issues.