### PR TITLE
ci: Add Explicit Error Message for Code Generation Test

### DIFF
--- a/.github/workflows/test-codegen.yaml
+++ b/.github/workflows/test-codegen.yaml
@@ -20,8 +20,15 @@ jobs:
     - name: Generate
       run: |
         make generate-all
-        # Expect all changes to be accounted for
-        ! git status --porcelain | grep .
+        # Check for uncommitted changes
+        if git status --porcelain | grep .; then
+          echo "::error::Uncommitted changes detected after code generation"
+          echo "=== Files Changed ==="
+          git status --porcelain
+          echo "=== Sample Diff (first 200 lines) ==="
+          git diff | head -200
+          exit 1
+        fi
     - name: Determine golangci-lint version
       id: golangcilint
       run: |

--- a/.github/workflows/test-codegen.yaml
+++ b/.github/workflows/test-codegen.yaml
@@ -18,10 +18,9 @@ jobs:
     - name: Verify Patches
       run: make patch-all
     - name: Generate
-      run: |
-        make generate-all
+      run: make generate-all
     - name: Check for uncommitted changes
-       run: |
+      run: |
         if git status --porcelain | grep .; then
           echo "::error::Uncommitted changes detected after code generation"
           echo "=== Files Changed ==="

--- a/.github/workflows/test-codegen.yaml
+++ b/.github/workflows/test-codegen.yaml
@@ -20,7 +20,8 @@ jobs:
     - name: Generate
       run: |
         make generate-all
-        # Check for uncommitted changes
+    - name: Check for uncommitted changes
+       run: |
         if git status --porcelain | grep .; then
           echo "::error::Uncommitted changes detected after code generation"
           echo "=== Files Changed ==="


### PR DESCRIPTION
~If the CI's `generate` test failed, explicitly logs uncommitted changes to help debugging.~

Add a CI step to check for uncommitted code change to help debugging.