### PR TITLE
fix: make the script cross-platform Linux/MacOS

### DIFF
--- a/script/onboard_service.sh
+++ b/script/onboard_service.sh
@@ -2,6 +2,19 @@
 
 set -eu
 
+
+function replace_in_file() {
+  local file="$1"
+  local search="$2"
+  local replace="$3"
+
+  # note that the following approach works on both GNU and BSD/Mac sed:
+  # see https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+  sed -i.bak "s|${search}|${replace}|g" "$file"
+  rm "${file}.bak"
+}
+
+
 echo "What service are you onboarding?"
 read service_name
 service_name=$(echo "$service_name" | tr '[:upper:]' '[:lower:]')
@@ -17,12 +30,12 @@ if [[ $possible_spec_filename == *"."* ]]; then
   spec_url=${spec_url%/$spec_root_file}
 fi
 cp templates/Makefile.sdk Makefile.${service_name}
-sed -i '' "s/__PACKAGE_NAME__/${service_name}/g" Makefile.${service_name}
-sed -i '' "s|__SPEC_BASE_URL__|${spec_url}|g" Makefile.${service_name}
-sed -i '' "s|__SPEC_ROOT_FILE__|${spec_root_file}|g" Makefile.${service_name}
+replace_in_file Makefile.${service_name} __PACKAGE_NAME__ "${service_name}"
+replace_in_file Makefile.${service_name} __SPEC_BASE_URL__ "${spec_url}"
+replace_in_file Makefile.${service_name} __SPEC_ROOT_FILE__ "${spec_root_file}"
 
 cp templates/.github/workflows/sync.yaml .github/workflows/sync-${service_name}.yaml
-sed -i '' "s/__PACKAGE_NAME__/${service_name}/g" .github/workflows/sync-${service_name}.yaml
+replace_in_file .github/workflows/sync-${service_name}.yaml __PACKAGE_NAME__ "${service_name}"
 
 mkdir -p spec/services/${service_name} && touch spec/services/${service_name}/.keep
 mkdir -p templates/services/${service_name} && touch templates/services/${service_name}/.keep


### PR DESCRIPTION
This PR makes the "make onboard-service" target compatible with both Linux and MacOS.
Tested on both platforms.