### PR TITLE
fix: remove format date-time for billingStartDateTime

### DIFF
--- a/services/ordersv2/docs/OrdersLine.md
+++ b/services/ordersv2/docs/OrdersLine.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **RootlineId** | Pointer to **string** | Unique identifier to specify root item. Useful when product order hierarchy exceeds 2. | [optional] 
 **Status** | Pointer to **string** | The current status of the order or service | [optional] 
 **Description** | Pointer to **string** | Description of the orders. | [optional] 
-**BillingStartDateTime** | Pointer to **string** | Billing commencement date and time in UTC timezone | [optional] 
+**BillingStartDateTime** | Pointer to **string** | Billing commencement date and time in UTC provided in the RFC3339 format with timezone markers omitted, delimitting date and time with a space, e.g. 2024-12-31 23:59:59 | [optional] 
 **EstimatedCompletionDateTime** | Pointer to **time.Time** | The estimated completion date and time in UTC timezone | [optional] 
 **UnitPricing** | Pointer to [**[]Price**](Price.md) | Unit Pricing details | [optional] 
 **TotalPricing** | Pointer to [**[]Price**](Price.md) | Total Pricing details | [optional] 

--- a/services/ordersv2/docs/OrdersLine.md
+++ b/services/ordersv2/docs/OrdersLine.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **RootlineId** | Pointer to **string** | Unique identifier to specify root item. Useful when product order hierarchy exceeds 2. | [optional] 
 **Status** | Pointer to **string** | The current status of the order or service | [optional] 
 **Description** | Pointer to **string** | Description of the orders. | [optional] 
-**BillingStartDateTime** | Pointer to **time.Time** | Billing commencement date and time in UTC timezone | [optional] 
+**BillingStartDateTime** | Pointer to **string** | Billing commencement date and time in UTC timezone | [optional] 
 **EstimatedCompletionDateTime** | Pointer to **time.Time** | The estimated completion date and time in UTC timezone | [optional] 
 **UnitPricing** | Pointer to [**[]Price**](Price.md) | Unit Pricing details | [optional] 
 **TotalPricing** | Pointer to [**[]Price**](Price.md) | Total Pricing details | [optional] 
@@ -172,20 +172,20 @@ HasDescription returns a boolean if a field has been set.
 
 ### GetBillingStartDateTime
 
-`func (o *OrdersLine) GetBillingStartDateTime() time.Time`
+`func (o *OrdersLine) GetBillingStartDateTime() string`
 
 GetBillingStartDateTime returns the BillingStartDateTime field if non-nil, zero value otherwise.
 
 ### GetBillingStartDateTimeOk
 
-`func (o *OrdersLine) GetBillingStartDateTimeOk() (*time.Time, bool)`
+`func (o *OrdersLine) GetBillingStartDateTimeOk() (*string, bool)`
 
 GetBillingStartDateTimeOk returns a tuple with the BillingStartDateTime field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetBillingStartDateTime
 
-`func (o *OrdersLine) SetBillingStartDateTime(v time.Time)`
+`func (o *OrdersLine) SetBillingStartDateTime(v string)`
 
 SetBillingStartDateTime sets BillingStartDateTime field to given value.
 

--- a/services/ordersv2/model_orders_line.go
+++ b/services/ordersv2/model_orders_line.go
@@ -30,7 +30,7 @@ type OrdersLine struct {
 	Status *string `json:"status,omitempty"`
 	// Description of the orders.
 	Description *string `json:"description,omitempty"`
-	// Billing commencement date and time in UTC timezone
+	// Billing commencement date and time in UTC provided in the RFC3339 format with timezone markers omitted, delimitting date and time with a space, e.g. 2024-12-31 23:59:59
 	BillingStartDateTime *string `json:"billingStartDateTime,omitempty"`
 	// The estimated completion date and time in UTC timezone
 	EstimatedCompletionDateTime *time.Time `json:"estimatedCompletionDateTime,omitempty"`

--- a/services/ordersv2/model_orders_line.go
+++ b/services/ordersv2/model_orders_line.go
@@ -31,7 +31,7 @@ type OrdersLine struct {
 	// Description of the orders.
 	Description *string `json:"description,omitempty"`
 	// Billing commencement date and time in UTC timezone
-	BillingStartDateTime *time.Time `json:"billingStartDateTime,omitempty"`
+	BillingStartDateTime *string `json:"billingStartDateTime,omitempty"`
 	// The estimated completion date and time in UTC timezone
 	EstimatedCompletionDateTime *time.Time `json:"estimatedCompletionDateTime,omitempty"`
 	// Unit Pricing details
@@ -247,9 +247,9 @@ func (o *OrdersLine) SetDescription(v string) {
 }
 
 // GetBillingStartDateTime returns the BillingStartDateTime field value if set, zero value otherwise.
-func (o *OrdersLine) GetBillingStartDateTime() time.Time {
+func (o *OrdersLine) GetBillingStartDateTime() string {
 	if o == nil || IsNil(o.BillingStartDateTime) {
-		var ret time.Time
+		var ret string
 		return ret
 	}
 	return *o.BillingStartDateTime
@@ -257,7 +257,7 @@ func (o *OrdersLine) GetBillingStartDateTime() time.Time {
 
 // GetBillingStartDateTimeOk returns a tuple with the BillingStartDateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *OrdersLine) GetBillingStartDateTimeOk() (*time.Time, bool) {
+func (o *OrdersLine) GetBillingStartDateTimeOk() (*string, bool) {
 	if o == nil || IsNil(o.BillingStartDateTime) {
 		return nil, false
 	}
@@ -273,8 +273,8 @@ func (o *OrdersLine) HasBillingStartDateTime() bool {
 	return false
 }
 
-// SetBillingStartDateTime gets a reference to the given time.Time and assigns it to the BillingStartDateTime field.
-func (o *OrdersLine) SetBillingStartDateTime(v time.Time) {
+// SetBillingStartDateTime gets a reference to the given string and assigns it to the BillingStartDateTime field.
+func (o *OrdersLine) SetBillingStartDateTime(v string) {
 	o.BillingStartDateTime = &v
 }
 

--- a/spec/services/ordersv2/oas3.patched/openapi.yaml
+++ b/spec/services/ordersv2/oas3.patched/openapi.yaml
@@ -1220,7 +1220,6 @@
                     },
                     "billingStartDateTime": {
                         "type": "string",
-                        "format": "datetime-local",
                         "description": "Billing commencement date and time in UTC provided in the RFC3339 format with timezone markers omitted, delimitting date and time with a space, e.g. 2024-12-31 23:59:59"
                     },
                     "estimatedCompletionDateTime": {

--- a/spec/services/ordersv2/oas3.patched/openapi.yaml
+++ b/spec/services/ordersv2/oas3.patched/openapi.yaml
@@ -1220,7 +1220,6 @@
                     },
                     "billingStartDateTime": {
                         "type": "string",
-                        "format": "date-time",
                         "description": "Billing commencement date and time in UTC timezone"
                     },
                     "estimatedCompletionDateTime": {

--- a/spec/services/ordersv2/oas3.patched/openapi.yaml
+++ b/spec/services/ordersv2/oas3.patched/openapi.yaml
@@ -1220,7 +1220,8 @@
                     },
                     "billingStartDateTime": {
                         "type": "string",
-                        "description": "Billing commencement date and time in UTC timezone"
+                        "format": "datetime-local",
+                        "description": "Billing commencement date and time in UTC provided in the RFC3339 format with timezone markers omitted, delimitting date and time with a space, e.g. 2024-12-31 23:59:59"
                     },
                     "estimatedCompletionDateTime": {
                         "type": "string",

--- a/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
+++ b/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
@@ -1,12 +1,14 @@
 diff --git a/spec/services/ordersv2/oas3.patched/openapi.yaml b/spec/services/ordersv2/oas3.patched/openapi.yaml
-index f5860251..a6177708 100644
+index a6177708..d4927d17 100644
 --- a/spec/services/ordersv2/oas3.patched/openapi.yaml
 +++ b/spec/services/ordersv2/oas3.patched/openapi.yaml
-@@ -1220,7 +1220,6 @@
+@@ -1220,7 +1220,8 @@
                      },
                      "billingStartDateTime": {
                          "type": "string",
--                        "format": "date-time",
-                         "description": "Billing commencement date and time in UTC timezone, e.g. '12/31/2024 23:59:59'"
+-                        "description": "Billing commencement date and time in UTC timezone"
++                        "format": "datetime-local",
++                        "description": "Billing commencement date and time in UTC provided in the RFC3339 format with timezone markers omitted, delimitting date and time with a space, e.g. 2024-12-31 23:59:59"
                      },
                      "estimatedCompletionDateTime": {
+                         "type": "string",

--- a/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
+++ b/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
@@ -1,11 +1,12 @@
 diff --git a/spec/services/ordersv2/oas3.patched/openapi.yaml b/spec/services/ordersv2/oas3.patched/openapi.yaml
-index a6177708..d4927d17 100644
+index f5860251..d4927d17 100644
 --- a/spec/services/ordersv2/oas3.patched/openapi.yaml
 +++ b/spec/services/ordersv2/oas3.patched/openapi.yaml
-@@ -1220,7 +1220,8 @@
+@@ -1220,8 +1220,8 @@
                      },
                      "billingStartDateTime": {
                          "type": "string",
+-                        "format": "date-time",
 -                        "description": "Billing commencement date and time in UTC timezone"
 +                        "format": "datetime-local",
 +                        "description": "Billing commencement date and time in UTC provided in the RFC3339 format with timezone markers omitted, delimitting date and time with a space, e.g. 2024-12-31 23:59:59"

--- a/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
+++ b/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
@@ -1,0 +1,12 @@
+diff --git a/spec/services/ordersv2/oas3.patched/openapi.yaml b/spec/services/ordersv2/oas3.patched/openapi.yaml
+index f5860251..a6177708 100644
+--- a/spec/services/ordersv2/oas3.patched/openapi.yaml
++++ b/spec/services/ordersv2/oas3.patched/openapi.yaml
+@@ -1220,7 +1220,6 @@
+                     },
+                     "billingStartDateTime": {
+                         "type": "string",
+-                        "format": "date-time",
+                         "description": "Billing commencement date and time in UTC timezone"
+                     },
+                     "estimatedCompletionDateTime": {

--- a/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
+++ b/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
@@ -1,14 +1,13 @@
 diff --git a/spec/services/ordersv2/oas3.patched/openapi.yaml b/spec/services/ordersv2/oas3.patched/openapi.yaml
-index f5860251..d4927d17 100644
+index f5860251..77614278 100644
 --- a/spec/services/ordersv2/oas3.patched/openapi.yaml
 +++ b/spec/services/ordersv2/oas3.patched/openapi.yaml
-@@ -1220,8 +1220,8 @@
+@@ -1220,8 +1220,7 @@
                      },
                      "billingStartDateTime": {
                          "type": "string",
 -                        "format": "date-time",
 -                        "description": "Billing commencement date and time in UTC timezone"
-+                        "format": "datetime-local",
 +                        "description": "Billing commencement date and time in UTC provided in the RFC3339 format with timezone markers omitted, delimitting date and time with a space, e.g. 2024-12-31 23:59:59"
                      },
                      "estimatedCompletionDateTime": {

--- a/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
+++ b/spec/services/ordersv2/patches/20250912_remove_billing_startdate_format.patch
@@ -7,6 +7,6 @@ index f5860251..a6177708 100644
                      "billingStartDateTime": {
                          "type": "string",
 -                        "format": "date-time",
-                         "description": "Billing commencement date and time in UTC timezone"
+                         "description": "Billing commencement date and time in UTC timezone, e.g. '12/31/2024 23:59:59'"
                      },
                      "estimatedCompletionDateTime": {


### PR DESCRIPTION
This PR is addressing the following failure when trying to use ordersv2 API:

```
{"L":"ERROR","T":"2025-09-11T15:49:09.319Z","M":"Orders v2 API `OrdersApi.GETOrderDetails` failed","err":"parsing time \"2024-05-09 06:03:14\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \" 06:03:14\" as \"T\"","orderId":"1-260421392589"}
```

due to the billingStartDateTime field containing strings like "2024-05-09 06:03:14" as opposed to "2024-05-09T06:03:14"