### PR TITLE
fix: remove explicit authorization header requirement for smarthandsv1

### DIFF
--- a/examples/services/smarthandsv1/get_smarthands_types/main.go
+++ b/examples/services/smarthandsv1/get_smarthands_types/main.go
@@ -71,22 +71,10 @@ func main() {
 	configuration.AddDefaultHeader("X-CORRELATION-ID", CORRELATION_ID)
 	client := smarthandsv1.NewAPIClient(configuration)
 
-	// Note: The Smart Hands API requires an explicit Authorization parameter
-	// in its API methods, unlike other Equinix APIs that rely solely on the
-	// OAuth2 transport. This is can be seen in Smart Hands v1 API spec.
-	// We need to get the token from the source and format it with "Bearer" prefix.
-	token, err := authTransport.Source.TokenWithContext(ctx)
-	if err != nil {
-		log.Fatalf("Failed to get authentication token: %v", err)
-	}
-	authToken := "Bearer " + token.AccessToken
-
 	// Get available Smart Hands service types
 	log.Println("Retrieving available Smart Hands service types...")
 
-	typesResp, resp, err := client.SmarthandsApi.SmartHandTypes(ctx).
-		Authorization(authToken).
-		Execute()
+	typesResp, resp, err := client.SmarthandsApi.SmartHandTypes(ctx).Execute()
 	if err != nil {
 		log.Printf("Error retrieving Smart Hands types: %v", err)
 		if resp != nil {

--- a/services/smarthandsv1/api_smarthands.go
+++ b/services/smarthandsv1/api_smarthands.go
@@ -94,9 +94,6 @@ func (a *SmarthandsApiService) GetLocationExecute(r ApiGetLocationRequest) (*Get
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return localVarReturnValue, nil, reportError("authorization is required and must be specified")
-	}
 
 	if r.detail != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "detail", r.detail, "", "")
@@ -127,7 +124,9 @@ func (a *SmarthandsApiService) GetLocationExecute(r ApiGetLocationRequest) (*Get
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -252,9 +251,6 @@ func (a *SmarthandsApiService) HandleSmartHandCableRequestOrderExecute(r ApiHand
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -273,7 +269,9 @@ func (a *SmarthandsApiService) HandleSmartHandCableRequestOrderExecute(r ApiHand
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -391,9 +389,6 @@ func (a *SmarthandsApiService) HandleSmartHandCageCleanupOrderExecute(r ApiHandl
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -412,7 +407,9 @@ func (a *SmarthandsApiService) HandleSmartHandCageCleanupOrderExecute(r ApiHandl
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -530,9 +527,6 @@ func (a *SmarthandsApiService) HandleSmartHandCageEscortOrderExecute(r ApiHandle
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -551,7 +545,9 @@ func (a *SmarthandsApiService) HandleSmartHandCageEscortOrderExecute(r ApiHandle
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -669,9 +665,6 @@ func (a *SmarthandsApiService) HandleSmartHandLocatePackageOrderExecute(r ApiHan
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -690,7 +683,9 @@ func (a *SmarthandsApiService) HandleSmartHandLocatePackageOrderExecute(r ApiHan
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -808,9 +803,6 @@ func (a *SmarthandsApiService) HandleSmartHandMoveJumperCableOrderExecute(r ApiH
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -829,7 +821,9 @@ func (a *SmarthandsApiService) HandleSmartHandMoveJumperCableOrderExecute(r ApiH
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -947,9 +941,6 @@ func (a *SmarthandsApiService) HandleSmartHandOrderExecute(r ApiHandleSmartHandO
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -968,7 +959,9 @@ func (a *SmarthandsApiService) HandleSmartHandOrderExecute(r ApiHandleSmartHandO
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -1086,9 +1079,6 @@ func (a *SmarthandsApiService) HandleSmartHandOthersOrderExecute(r ApiHandleSmar
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1107,7 +1097,9 @@ func (a *SmarthandsApiService) HandleSmartHandOthersOrderExecute(r ApiHandleSmar
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -1225,9 +1217,6 @@ func (a *SmarthandsApiService) HandleSmartHandPatchCableInstallOrderExecute(r Ap
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1246,7 +1235,9 @@ func (a *SmarthandsApiService) HandleSmartHandPatchCableInstallOrderExecute(r Ap
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -1364,9 +1355,6 @@ func (a *SmarthandsApiService) HandleSmartHandPatchCableRemovalOrderExecute(r Ap
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1385,7 +1373,9 @@ func (a *SmarthandsApiService) HandleSmartHandPatchCableRemovalOrderExecute(r Ap
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -1503,9 +1493,6 @@ func (a *SmarthandsApiService) HandleSmartHandPicturesDocumentOrderExecute(r Api
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1524,7 +1511,9 @@ func (a *SmarthandsApiService) HandleSmartHandPicturesDocumentOrderExecute(r Api
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -1642,9 +1631,6 @@ func (a *SmarthandsApiService) HandleSmartHandRunJumperCableOrderExecute(r ApiHa
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1663,7 +1649,9 @@ func (a *SmarthandsApiService) HandleSmartHandRunJumperCableOrderExecute(r ApiHa
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -1781,9 +1769,6 @@ func (a *SmarthandsApiService) HandleSmartHandShipmentUnpackOrderExecute(r ApiHa
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1802,7 +1787,9 @@ func (a *SmarthandsApiService) HandleSmartHandShipmentUnpackOrderExecute(r ApiHa
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	// body params
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
@@ -1917,9 +1904,6 @@ func (a *SmarthandsApiService) SmartHandTypesExecute(r ApiSmartHandTypesRequest)
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.authorization == nil {
-		return localVarReturnValue, nil, reportError("authorization is required and must be specified")
-	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -1938,7 +1922,9 @@ func (a *SmarthandsApiService) SmartHandTypesExecute(r ApiSmartHandTypesRequest)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	if r.authorization != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Authorization", r.authorization, "", "")
+	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/services/smarthandsv1/docs/SmarthandsApi.md
+++ b/services/smarthandsv1/docs/SmarthandsApi.md
@@ -42,7 +42,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	detail := true // bool | When enable this flag returns detailed permission with Cage & Cabinets. (optional) (default to false)
 	ibxs := "ibxs_example" // string | Example: AM1,AM2 (optional)
 	cages := "cages_example" // string | Example: AM1:02:002MC1 (optional)
@@ -114,7 +114,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewCableRequestRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewCableRequestRequestServiceDetails(openapiclient.cableRequestRequest_serviceDetails_quantity("1"), "Scope of work")) // CableRequestRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -180,7 +180,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewCageCleanupRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewCageCleanupRequestServiceDetails(false, true, "Scope of work")) // CageCleanupRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -246,7 +246,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewCageEscortRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewCageEscortRequestServiceDetails(openapiclient.cageEscortRequest_serviceDetails_durationVisit("30 Minutes"), false, "Scope of work", false, "1-108050984499")) // CageEscortRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -312,7 +312,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewLocatePackageRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewLocatePackageRequestServiceDetails("1-1111111111", "323-12121", "Near cabinet 1010", "It's small box with 1kg weight.", "Scope of work")) // LocatePackageRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -378,7 +378,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewMoveJumperCableRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewMoveJumperCableRequestServiceDetails(openapiclient.moveJumperCableRequest_serviceDetails_quantity("1"), "Scope of work")) // MoveJumperCableRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -444,7 +444,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewEquipmentInstallRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewEquipmentInstallRequestServiceDetails("abc location", false, "abc", false, true, true, true, "Scope of work")) // EquipmentInstallRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -510,7 +510,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewOtherRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewOtherRequestServiceDetails("Scope of work")) // OtherRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -576,7 +576,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewPatchCableInstallRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewPatchCableInstallRequestServiceDetails([]openapiclient.CrossConnectInstall{*openapiclient.NewCrossConnectInstall("SerialNumber_example", "DeviceCabinet_example", "DeviceConnectorType_example", "DeviceDetails_example", "DevicePort_example")})) // PatchCableInstallRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -642,7 +642,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewPatchCableRemovalRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewPatchCableRemovalRequestServiceDetails([]openapiclient.CrossConnectRemoval{*openapiclient.NewCrossConnectRemoval("SerialNumber_example", "DeviceCabinet_example", "DeviceConnectorType_example", "DeviceDetails_example", "DevicePort_example")})) // PatchCableRemovalRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -708,7 +708,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewPicturesDocumentRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewPicturesDocumentRequestServiceDetails(true, "Scope of work")) // PicturesDocumentRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -774,7 +774,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewRunJumperCableRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewRunJumperCableRequestServiceDetails(openapiclient.moveJumperCableRequest_serviceDetails_quantity("1"), "Scope of work")) // RunJumperCableRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -840,7 +840,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 	body := *openapiclient.NewShipmentUnpackRequest(*openapiclient.NewIbxLocation("AM1", []openapiclient.IbxLocationCagesInner{*openapiclient.NewIbxLocationCagesInner("AM1:01:001MC3", "12345")}), []openapiclient.ContactInfo{*openapiclient.NewContactInfo(openapiclient.contactInfo_contactType("TECHNICAL"))}, *openapiclient.NewScheduleInfo(openapiclient.scheduleInfo_scheduleType("STANDARD")), *openapiclient.NewShipmentUnpackRequestServiceDetails("1-12122121", false, "Scope of work", false)) // ShipmentUnpackRequest |  (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -906,7 +906,7 @@ import (
 )
 
 func main() {
-	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'.
+	authorization := "authorization_example" // string | Specify the Access token with prefix 'Bearer'. (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/spec/services/smarthandsv1/oas3.patched/openapi.yaml
+++ b/spec/services/smarthandsv1/oas3.patched/openapi.yaml
@@ -2673,7 +2673,7 @@
       "in": "header",
       "description": "Specify the Access token with prefix 'Bearer'.",
       "type": "string",
-      "required": true
+      "required": false
     }
   }
 }

--- a/spec/services/smarthandsv1/patches/20250915_fix_authorization.patch
+++ b/spec/services/smarthandsv1/patches/20250915_fix_authorization.patch
@@ -1,0 +1,14 @@
+diff --git a/spec/services/smarthandsv1/oas3.patched/openapi.yaml b/spec/services/smarthandsv1/oas3.patched/openapi.yaml
+index 7c14c6a3..af5d633f 100644
+--- a/spec/services/smarthandsv1/oas3.patched/openapi.yaml
++++ b/spec/services/smarthandsv1/oas3.patched/openapi.yaml
+@@ -2673,7 +2673,7 @@
+       "in": "header",
+       "description": "Specify the Access token with prefix 'Bearer'.",
+       "type": "string",
+-      "required": true
++      "required": false
+     }
+   }
+ }
+\ No newline at end of file


### PR DESCRIPTION
  ## Overview
This PR patches smarthandsv1 OAPI spec to removed explicit authorization header requirement from smarthandsv1 OpenAPI spec. Authentication for smarthandv1 service is now handled automatically through the HTTP client's auth transport, which is consistent with other services in Equinix-SDK.

smarthandsv1 example has been updated to reflect the change.

  ## Motivation
The smarthandsv1 service was the only remaining service requiring explicit authorization header management in API calls. This change makes it consistent with other services in the SDK. With this change, downstream services can take advantage of the auth package provided by Equinix-SDK and no longer need to explicit manage and pass in oauth token.