### PR TITLE
docs: warn about removal of Metal code ahead of Equinix Metal EoL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Equinix Go SDK
 
+> [!WARNING]
+> With the upcoming EoL of Equinix Metal on June 30, 2026, all Metal-related code (the `metalv1` package) will be removed from this SDK. Other Equinix services will continue to be supported.
+
 [![Release](https://img.shields.io/github/v/release/equinix/equinix-sdk-go)](https://github.com/equinix/equinix-sdk-go/releases/latest)
 [![GoDoc](https://godoc.org/github.com/equinix/equinix-sdk-go?status.svg)](https://godoc.org/github.com/equinix/equinix-sdk-go)
 


### PR DESCRIPTION
## Summary

Adds a warning notice to the README about the upcoming removal of all Metal-related code (the `metalv1` package) from the SDK, ahead of the Equinix Metal EoL on June 30, 2026.

The notice clarifies that other Equinix services will continue to be supported (this is a multi-service SDK, so the repo is not being archived).

Relates to [BMS-1957](https://equinixjira.atlassian.net/browse/BMS-1957).

## Changes
- README.md: add `> [!WARNING]` block under the title, above the badges.

## Notes
- PR title follows Conventional Commits (`docs:`) to satisfy the Validate PR Title workflow.
- A `docs:` change does not trigger a semantic-release version bump.